### PR TITLE
Rename Tool Management Features for Better Clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- (Planned features for v1.4.0 will be listed here)
+- New configuration hot reload system with merged config from multiple sources
 
 ### Changed
 - Internationalized codebase by converting all comments to English
+- Renamed "Direct Registration" feature to "Tool Aliasing" for better clarity (`directTools` → `toolAliases`)
+- Renamed "Registration Patterns" feature to "Auto Tool Discovery" for better clarity (`registrationPatterns` → `toolDiscoveryRules`)
+- Improved backward compatibility with legacy configuration field names
 
 ## [1.3.0] - 2025-06-15
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ A TypeScript-based HTTP gateway for multiple STDIO-based MCP (Model Context Prot
 - **Multi-Server Support**: Connect to multiple MCP servers simultaneously
 - **Dynamic Configuration**: JSON-based server configuration with environment variable expansion
 - **Tool Name Conflict Resolution**: Automatic detection and namespace-based resolution
-- **Tool Registration Patterns**: Automatically register tools matching wildcard patterns
+- **Auto Tool Discovery**: Automatically discover and register tools matching wildcard patterns
 - **Internal Tool Registry**: Manages tools directly within the bridge for efficient access
-- **Direct Tool Registration**: Register tools from any server for direct access
+- **Tool Aliasing**: Create aliases for tools from any server for direct access
 - **Robust Error Handling**: Comprehensive error handling for all transport types
 - **Comprehensive Logging**: Detailed logging for debugging MCP connections
 - **Type Safety**: Full TypeScript implementation with strict type checking

--- a/docs/tool-management.md
+++ b/docs/tool-management.md
@@ -1,0 +1,99 @@
+# Tool Management in MCP Bridge
+
+MCP Bridge provides two complementary approaches to manage tools from connected MCP servers: **Tool Aliasing** and **Auto Tool Discovery**.
+
+## Tool Aliasing (formerly "Direct Registration")
+
+Tool Aliasing allows you to create aliases for specific tools from any connected MCP server. This makes them directly accessible at the bridge's root level without requiring namespace prefixing.
+
+### Configuration
+
+Tool aliases can be defined in the configuration file:
+
+```json
+{
+  "servers": [...],
+  "toolAliases": [
+    {
+      "serverId": "google-search",
+      "toolName": "web_search",
+      "newName": "search"  // Optional custom name
+    },
+    {
+      "serverId": "filesystem",
+      "toolName": "read_file"
+    }
+  ]
+}
+```
+
+### Usage Example
+
+When a tool is aliased, it can be accessed directly via the bridge:
+
+```
+// Without aliasing:
+POST /mcp/call/google-search/web_search
+    
+// With aliasing:
+POST /mcp/call/search
+```
+
+### API Tools
+
+- `create_tool_alias`: Create an alias for a server tool
+- `remove_tool_alias`: Remove a tool alias
+- `list_aliased_tools`: List all tool aliases
+
+## Auto Tool Discovery (formerly "Registration Patterns")
+
+Auto Tool Discovery provides a way to automatically discover and register multiple tools based on wildcard patterns. This feature is especially useful for quickly exposing many tools without manually configuring each one.
+
+### Configuration
+
+```json
+{
+  "servers": [...],
+  "toolDiscoveryRules": [
+    {
+      "serverPattern": "*",         // Match all servers
+      "toolPattern": "get_*",       // Only tools starting with "get_"
+      "exclude": false              // Include matching tools (default)
+    },
+    {
+      "serverPattern": "internal-*",
+      "toolPattern": "*_private",
+      "exclude": true               // Exclude matching tools
+    }
+  ]
+}
+```
+
+### Pattern Matching
+
+- `*`: Matches any number of characters
+- `?`: Matches exactly one character
+- Rules are evaluated in order, with later exclude rules taking precedence
+
+### Behavior
+
+1. When the MCP Bridge starts or configuration is reloaded
+2. It scans all connected servers for available tools
+3. Each tool is checked against the discovery rules
+4. Matching tools are automatically registered as direct aliases
+
+## Combining Both Features
+
+Tool Aliasing and Auto Tool Discovery can be used together:
+
+1. Use Auto Tool Discovery for broad tool registration based on patterns
+2. Use Tool Aliasing for specific tools requiring custom names or targeted access
+
+## Backward Compatibility
+
+For backward compatibility, the old configuration field names are still supported:
+
+- `directTools` → `toolAliases` 
+- `registrationPatterns` → `toolDiscoveryRules`
+
+However, using the old names will generate deprecation warnings in the logs.

--- a/examples/mcp-config-multi-transport.json
+++ b/examples/mcp-config-multi-transport.json
@@ -33,6 +33,20 @@
       "maxRestarts": 3
     }
   ],
+  "toolDiscoveryRules": [
+    {
+      "serverPattern": "*-stdio",
+      "toolPattern": "*",
+      "exclude": false
+    }
+  ],
+  "toolAliases": [
+    {
+      "serverId": "test-sse-server",
+      "toolName": "get_data",
+      "newName": "sse_data"
+    }
+  ],
   "global": {
     "logLevel": "info",
     "maxConcurrentConnections": 10,

--- a/examples/mcp-config-with-patterns.json
+++ b/examples/mcp-config-with-patterns.json
@@ -37,7 +37,7 @@
       "maxRestarts": 3
     }
   ],
-  "registrationPatterns": [
+  "toolDiscoveryRules": [
     {
       "serverPattern": "filesystem",
       "toolPattern": "*",
@@ -54,7 +54,7 @@
       "exclude": true
     }
   ],
-  "directTools": [
+  "toolAliases": [
     {
       "serverId": "brave-search",
       "toolName": "search",

--- a/rename-plan.md
+++ b/rename-plan.md
@@ -1,0 +1,63 @@
+# ツール管理機能のリネーム計画
+
+## 目的
+MCP Bridgeの「Direct Registration」と「Tool Export/Registration Patterns」機能に、より直感的でわかりやすい英語の名前を付ける。
+
+## 新しい名前の提案
+1. 「Direct Registration」→「**Tool Aliasing**」（ツールのエイリアス化）
+2. 「Registration Patterns」→「**Auto Tool Discovery**」（ツールの自動検出）
+
+## 実装計画
+
+### 1. コード変更
+- [ ] src/bridge-tool-registry.ts - メイン機能コード
+- [ ] src/config/mcp-config.ts - 設定スキーマ定義
+- [ ] mcp-config.json - サンプル設定ファイル
+- [ ] test-config.json - テスト設定ファイル
+- [ ] test-config-updated.json - テスト設定ファイル更新版
+- [ ] examples/ 内のサンプル設定ファイル
+
+### 2. 名前の変更一覧
+
+#### Direct Registration → Tool Aliasing 関連
+- [ ] `directTools` → `toolAliases`
+- [ ] `register_direct_tool` → `create_tool_alias`
+- [ ] `unregister_direct_tool` → `remove_tool_alias`
+- [ ] `handleRegisterDirectTool` → `handleCreateToolAlias`
+- [ ] `handleUnregisterDirectTool` → `handleRemoveToolAlias`
+- [ ] `registerDirectTool` → `createToolAlias`
+- [ ] その他関連する変数名、関数名、コメント
+
+#### Registration Patterns → Auto Tool Discovery 関連
+- [ ] `registrationPatterns` → `toolDiscoveryRules`
+- [ ] `applyRegistrationPatterns` → `applyDiscoveryRules`
+- [ ] `shouldRegisterTool` → `shouldDiscoverTool`
+- [ ] その他関連する変数名、関数名、コメント
+
+### 3. ドキュメント更新
+- [ ] README.md - 機能の説明を更新
+- [ ] CHANGELOG.md - 変更内容を追加
+- [ ] コードコメントの更新
+- [ ] 新しい機能説明ドキュメントの作成（docs/tool-management.md）
+
+### 4. 後方互換性の確保
+- [ ] 古い設定フォーマットを読み込める移行コードの追加
+- [ ] 非推奨警告の出力（古い名前が使用された場合）
+
+### 5. テスト
+- [ ] 既存のテストを更新
+- [ ] 新しい名前での動作確認テスト
+- [ ] 後方互換性テスト
+
+## スケジュール
+1. コード変更（1-2日）
+2. ドキュメント更新（1日）
+3. テスト実行と修正（1日）
+4. コードレビュー（1-2日）
+5. マージとリリース（1日）
+
+## レビュー視点
+- 新しい名称が直感的か
+- 後方互換性が適切に維持されているか
+- ドキュメントが明確に更新されているか
+- コードの品質が維持されているか

--- a/src/config/mcp-config.ts
+++ b/src/config/mcp-config.ts
@@ -44,11 +44,25 @@ export type MCPServerConfig = z.infer<typeof MCPServerConfigSchema>;
 // Schema for the complete MCP configuration file
 export const MCPConfigSchema = z.object({
   servers: z.array(MCPServerConfigSchema),
+  toolAliases: z.array(
+    z.object({
+      serverId: z.string(),
+      toolName: z.string(),
+      newName: z.string().optional(),
+    })
+  ).optional(),
   directTools: z.array(
     z.object({
       serverId: z.string(),
       toolName: z.string(),
       newName: z.string().optional(),
+    })
+  ).optional().describe('DEPRECATED: Use toolAliases instead'),
+  toolDiscoveryRules: z.array(
+    z.object({
+      serverPattern: z.string().describe('Server ID pattern (wildcards *,? supported)'),
+      toolPattern: z.string().describe('Tool name pattern (wildcards *,? supported)'),
+      exclude: z.boolean().default(false).describe('Whether to use as an exclusion pattern'),
     })
   ).optional(),
   registrationPatterns: z.array(
@@ -57,7 +71,7 @@ export const MCPConfigSchema = z.object({
       toolPattern: z.string().describe('Tool name pattern (wildcards *,? supported)'),
       exclude: z.boolean().default(false).describe('Whether to use as an exclusion pattern'),
     })
-  ).optional(),
+  ).optional().describe('DEPRECATED: Use toolDiscoveryRules instead'),
   global: z.object({
     logLevel: z.enum(['debug', 'info', 'warn', 'error']).default('info'),
     maxConcurrentConnections: z.number().default(10),

--- a/src/mcp-http-server.ts
+++ b/src/mcp-http-server.ts
@@ -321,7 +321,8 @@ export class MCPHttpServer {
               }]
             };
             
-          case 'register_direct_tool':
+          case 'create_tool_alias':
+          case 'register_direct_tool': // 後方互換性のため
             if (!args.serverId || !args.toolName) {
               throw new Error('serverId and toolName are required');
             }
@@ -353,7 +354,7 @@ export class MCPHttpServer {
                 throw new Error('Bridge Tool Registry is not available');
               }
               
-              const toolRegistrationResult = await bridgeToolRegistry.handleRegisterDirectTool({
+              const toolRegistrationResult = await bridgeToolRegistry.handleCreateToolAlias({
                 serverId: serverId,
                 toolName: originalToolName,
                 newName: toolName
@@ -379,7 +380,8 @@ export class MCPHttpServer {
               };
             }
             
-          case 'unregister_direct_tool':
+          case 'remove_tool_alias':
+          case 'unregister_direct_tool': // 後方互換性のため
             if (!args.toolName) {
               throw new Error('toolName is required');
             }
@@ -394,7 +396,7 @@ export class MCPHttpServer {
                 throw new Error('Bridge Tool Registry is not available');
               }
               
-              const unregisterResult = await bridgeToolRegistry.handleUnregisterDirectTool({
+              const unregisterResult = await bridgeToolRegistry.handleRemoveToolAlias({
                 toolName
               });
               
@@ -418,7 +420,8 @@ export class MCPHttpServer {
               };
             }
             
-          case 'list_registered_tools':
+          case 'list_aliased_tools':
+          case 'list_registered_tools': // 後方互換性のため
             try {
               logger.info(`Listing registered tools via HTTP`);
               
@@ -428,7 +431,7 @@ export class MCPHttpServer {
                 throw new Error('Bridge Tool Registry is not available');
               }
               
-              const listResult = await bridgeToolRegistry.handleListRegisteredTools();
+              const listResult = await bridgeToolRegistry.handleListAliasedTools();
               
               return {
                 content: [{

--- a/test-config-updated.json
+++ b/test-config-updated.json
@@ -31,7 +31,7 @@
       "timeout": 10000
     }
   ],
-  "registrationPatterns": [
+  "toolDiscoveryRules": [
     {
       "serverPattern": "*",
       "toolPattern": "*",

--- a/test-config.json
+++ b/test-config.json
@@ -31,7 +31,7 @@
       "timeout": 10000
     }
   ],
-  "registrationPatterns": [
+  "toolDiscoveryRules": [
     {
       "serverPattern": "*",
       "toolPattern": "*",


### PR DESCRIPTION
This PR renames the tool management features for better clarity:

* 'Direct Registration' → 'Tool Aliasing' 
* 'Registration Patterns' → 'Auto Tool Discovery'

Includes backwards compatibility, documentation updates, and consistent naming throughout the codebase.

Fixes #16