### PR TITLE
Implement PKCE utilities and base provider

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -190,15 +190,14 @@ If you encounter:
 
 ## 🎯 Current Focus
 
-**NEXT IMMEDIATE TASK**: Implement configuration template system
-1. Create `src/config/config-template-engine.ts`
-2. Create `src/config/config-validation.ts`
-3. Define base templates for server configuration
-4. Continue updating checklist progress
-5. Implement dynamic constraint validation
+**NEXT IMMEDIATE TASK**: Implement PKCE utilities and base provider
+1. Create `src/auth/utils/pkce-utils.ts`
+2. Create `src/auth/providers/base-provider.ts`
+3. Update `docs/oidc-oauth2-checklist.md` progress
+4. Document any issues encountered
 
 ---
 
-**Last Updated**: 2025年6月18日 (template system completed)
+**Last Updated**: 2025年6月18日 (PKCE utilities started)
 **Current Phase**: Phase 1 - Security Foundation
 **Next Milestone**: Configuration Template System

--- a/docs/oidc-oauth2-checklist.md
+++ b/docs/oidc-oauth2-checklist.md
@@ -35,9 +35,9 @@
 - [x] `src/auth/types/rbac-types.ts` - RBAC関連の型定義
 
 ### 1.3 OIDC/OAuth2 基盤
-- [ ] `src/auth/providers/base-provider.ts` - プロバイダー基底クラス
+- [x] `src/auth/providers/base-provider.ts` - プロバイダー基底クラス
  - [x] `src/auth/utils/jwt-utils.ts` - JWT検証/生成ユーティリティ
-- [ ] `src/auth/utils/pkce-utils.ts` - PKCE実装
+- [x] `src/auth/utils/pkce-utils.ts` - PKCE実装
 - [ ] `src/auth/utils/crypto-utils.ts` - 暗号化ユーティリティ
 
 ### 1.4 認証フロー実装

--- a/src/auth/providers/base-provider.ts
+++ b/src/auth/providers/base-provider.ts
@@ -1,0 +1,39 @@
+import { OIDCProviderMetadata, OIDCTokenResponse, OIDCUserInfo } from '../types/oidc-types.js';
+import { PKCECodes } from '../utils/pkce-utils.js';
+import { logger } from '../../utils/logger.js';
+
+export interface OAuthProviderConfig {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+  scope?: string;
+}
+
+export abstract class BaseProvider {
+  constructor(
+    public readonly id: string,
+    protected readonly metadata: OIDCProviderMetadata,
+    protected readonly config: OAuthProviderConfig
+  ) {}
+
+  abstract getAuthorizationUrl(state: string, pkce: PKCECodes): string;
+
+  protected async requestToken(params: Record<string, string>): Promise<OIDCTokenResponse> {
+    const body = new URLSearchParams(params).toString();
+    const res = await fetch(this.metadata.tokenEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      logger.error(`Token request failed: ${res.status} ${text}`);
+      throw new Error(`Token request failed with status ${res.status}`);
+    }
+
+    return res.json() as Promise<OIDCTokenResponse>;
+  }
+
+  abstract getUserInfo(accessToken: string): Promise<OIDCUserInfo | undefined>;
+}

--- a/src/auth/utils/pkce-utils.ts
+++ b/src/auth/utils/pkce-utils.ts
@@ -1,0 +1,41 @@
+import crypto from 'crypto';
+
+export interface PKCECodes {
+  codeVerifier: string;
+  codeChallenge: string;
+  method: 'S256';
+}
+
+function base64UrlEncode(buffer: Buffer): string {
+  return buffer
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+export function generateCodeVerifier(length = 128): string {
+  const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~';
+  const random = crypto.randomBytes(length);
+  let verifier = '';
+  for (const byte of random) {
+    verifier += charset[byte % charset.length];
+  }
+  return verifier;
+}
+
+export function generateCodeChallenge(codeVerifier: string): string {
+  const hash = crypto.createHash('sha256').update(codeVerifier).digest();
+  return base64UrlEncode(hash);
+}
+
+export function generatePKCECodes(length = 64): PKCECodes {
+  const codeVerifier = generateCodeVerifier(length);
+  const codeChallenge = generateCodeChallenge(codeVerifier);
+  return { codeVerifier, codeChallenge, method: 'S256' };
+}
+
+export function verifyCodeChallenge(codeVerifier: string, expectedChallenge: string): boolean {
+  const actual = generateCodeChallenge(codeVerifier);
+  return actual === expectedChallenge;
+}


### PR DESCRIPTION
## Summary
- add PKCE helper functions for OAuth flows
- implement base provider class for OAuth providers
- mark PKCE and base provider as done in checklist
- update agent instructions for new immediate task

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851fccb233c83279169d90cdcaea7e2