### PR TITLE
Add Codex network restriction docs

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -167,6 +167,10 @@ Before implementing any feature, verify:
 4. **Proper Logging**: All security-related events must be logged
 5. **Database Safety**: Always use transactions for multi-step operations
 
+## 🌐 Codex Network Notes
+- All outbound requests go through `http://proxy:8080` and may be logged.
+- Some domains are blocked and return `403 Forbidden`; see `docs/codex-network-restrictions.md` for details.
+
 ## 🔄 Regular Tasks
 
 ### Daily

--- a/docs/codex-network-restrictions.md
+++ b/docs/codex-network-restrictions.md
@@ -1,0 +1,17 @@
+# Codex Network Restrictions
+
+This repository is designed to operate in the Codex environment. The environment uses an HTTP(S) proxy for all outbound network traffic and blocks some domains. Important behaviors observed:
+
+- **Proxy**: All requests go through `http://proxy:8080`. The proxy's root certificate is installed at `/usr/local/share/ca-certificates/envoy-mitmproxy-ca-cert.crt`.
+- **Environment variables**: `HTTP_PROXY` and `HTTPS_PROXY` are set to `http://proxy:8080` while `NO_PROXY` excludes `localhost`.
+- **Monitoring**: The proxy intercepts TLS connections, so all requests are logged.
+- **Blocked domains**: Certain domains return `403 Forbidden`. For example, `nytimes.com` is blocked:
+
+  ```bash
+  $ curl -I https://nytimes.com
+  HTTP/1.1 403 Forbidden
+  ```
+- **Allowed domains**: Many standard sites (e.g., `example.com`, `github.com`) are reachable.
+- **Partial access**: Some OpenAI documentation pages respond with `403`, likely due to additional access restrictions.
+
+When network access fails unexpectedly, check the proxy logs or try a different domain. Be mindful that all requests may be audited.


### PR DESCRIPTION
## Summary
- document Codex environment network restrictions
- add note about blocked domains to AGENT instructions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851fd2d82508327a492e99520e77c75