### PR TITLE
Implement crypto utils and tests

### DIFF
--- a/docs/oidc-oauth2-checklist.md
+++ b/docs/oidc-oauth2-checklist.md
@@ -38,7 +38,7 @@
 - [x] `src/auth/providers/base-provider.ts` - プロバイダー基底クラス
  - [x] `src/auth/utils/jwt-utils.ts` - JWT検証/生成ユーティリティ
 - [x] `src/auth/utils/pkce-utils.ts` - PKCE実装
-- [ ] `src/auth/utils/crypto-utils.ts` - 暗号化ユーティリティ
+- [x] `src/auth/utils/crypto-utils.ts` - 暗号化ユーティリティ
 
 ### 1.4 認証フロー実装
 - [ ] `src/auth/managers/auth-manager.ts` - 認証フローの中央管理

--- a/src/auth/utils/crypto-utils.ts
+++ b/src/auth/utils/crypto-utils.ts
@@ -1,0 +1,54 @@
+import crypto from 'crypto';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * Generate a random hexadecimal string.
+ * @param length number of bytes
+ */
+export function generateRandomString(length = 32): string {
+  return crypto.randomBytes(length).toString('hex');
+}
+
+/**
+ * Generate SHA-256 hash of input.
+ */
+export function hashSHA256(input: string): string {
+  return crypto.createHash('sha256').update(input).digest('hex');
+}
+
+/**
+ * Encrypt plaintext using AES-256-CBC. Returns a string in the form iv:cipher.
+ */
+export function encrypt(text: string, key: string): string {
+  try {
+    const iv = crypto.randomBytes(16);
+    const keyHash = crypto.createHash('sha256').update(key).digest();
+    const cipher = crypto.createCipheriv('aes-256-cbc', keyHash, iv);
+    const encrypted = Buffer.concat([cipher.update(text, 'utf8'), cipher.final()]);
+    return `${iv.toString('hex')}:${encrypted.toString('hex')}`;
+  } catch (err) {
+    logger.error('Encryption failed', err);
+    throw err;
+  }
+}
+
+/**
+ * Decrypt ciphertext produced by {@link encrypt}.
+ */
+export function decrypt(data: string, key: string): string {
+  try {
+    const [ivHex, encryptedHex] = data.split(':');
+    if (!ivHex || !encryptedHex) {
+      throw new Error('Invalid encrypted data format');
+    }
+    const iv = Buffer.from(ivHex, 'hex');
+    const encrypted = Buffer.from(encryptedHex, 'hex');
+    const keyHash = crypto.createHash('sha256').update(key).digest();
+    const decipher = crypto.createDecipheriv('aes-256-cbc', keyHash, iv);
+    const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+    return decrypted.toString('utf8');
+  } catch (err) {
+    logger.error('Decryption failed', err);
+    throw err;
+  }
+}

--- a/tests/auth/crypto-utils.test.ts
+++ b/tests/auth/crypto-utils.test.ts
@@ -1,0 +1,25 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { encrypt, decrypt, generateRandomString, hashSHA256 } from '../../src/auth/utils/crypto-utils.js';
+
+test('encrypt and decrypt roundtrip', () => {
+  const key = 'my_secret_key';
+  const message = 'hello world';
+  const encrypted = encrypt(message, key);
+  assert.notEqual(encrypted, message);
+  const decrypted = decrypt(encrypted, key);
+  assert.equal(decrypted, message);
+});
+
+test('generateRandomString returns hex string of expected length', () => {
+  const s = generateRandomString(16);
+  assert.equal(s.length, 32); // 16 bytes -> 32 hex chars
+  assert.match(s, /^[0-9a-f]+$/);
+});
+
+test('hashSHA256 generates deterministic hash', () => {
+  const h1 = hashSHA256('test');
+  const h2 = hashSHA256('test');
+  assert.equal(h1, h2);
+  assert.match(h1, /^[0-9a-f]{64}$/);
+});


### PR DESCRIPTION
## Summary
- implement encryption utilities
- mark crypto-utils checklist item
- add unit tests for crypto-utils

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852013ab7188327b9c3401f5e745b22