### PR TITLE
Implement crypto utils and tests

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -202,6 +202,6 @@ If you encounter:
 
 ---
 
-**Last Updated**: 2025年6月17日 (PKCE utilities completed)
+**Last Updated**: 2025年6月18日 (crypto utils implemented)
 **Current Phase**: Phase 1 - Security Foundation
 **Next Milestone**: Configuration Template System

--- a/AGENT.md
+++ b/AGENT.md
@@ -202,6 +202,6 @@ If you encounter:
 
 ---
 
-**Last Updated**: 2025年6月18日 (crypto utils implemented)
+**Last Updated**: 2025年6月18日 (crypto utils implemented, conflicts resolved)
 **Current Phase**: Phase 1 - Security Foundation
 **Next Milestone**: Configuration Template System

--- a/docs/oidc-oauth2-checklist.md
+++ b/docs/oidc-oauth2-checklist.md
@@ -38,7 +38,7 @@
 - [x] `src/auth/providers/base-provider.ts` - プロバイダー基底クラス
  - [x] `src/auth/utils/jwt-utils.ts` - JWT検証/生成ユーティリティ
 - [x] `src/auth/utils/pkce-utils.ts` - PKCE実装
-- [ ] `src/auth/utils/crypto-utils.ts` - 暗号化ユーティリティ
+- [x] `src/auth/utils/crypto-utils.ts` - 暗号化ユーティリティ
 
 ### 1.4 認証フロー実装
 - [ ] `src/auth/managers/auth-manager.ts` - 認証フローの中央管理

--- a/src/auth/utils/crypto-utils.ts
+++ b/src/auth/utils/crypto-utils.ts
@@ -1,0 +1,47 @@
+import crypto from 'crypto';
+
+export function generateRandomBytes(size = 32): Buffer {
+  return crypto.randomBytes(size);
+}
+
+export function generateRandomString(size = 32): string {
+  return generateRandomBytes(size).toString('hex');
+}
+
+export function hashSHA256(data: string | Buffer): string {
+  return crypto.createHash('sha256').update(data).digest('hex');
+}
+
+export interface EncryptedData {
+  iv: string;
+  tag: string;
+  data: string;
+}
+
+export function encryptAESGCM(plaintext: string, key: string): EncryptedData {
+  const iv = crypto.randomBytes(12);
+  const keyBuf = crypto.createHash('sha256').update(key).digest();
+  const cipher = crypto.createCipheriv('aes-256-gcm', keyBuf, iv);
+  const enc = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return {
+    iv: iv.toString('hex'),
+    tag: tag.toString('hex'),
+    data: enc.toString('hex')
+  };
+}
+
+export function decryptAESGCM(encrypted: EncryptedData, key: string): string {
+  const iv = Buffer.from(encrypted.iv, 'hex');
+  const tag = Buffer.from(encrypted.tag, 'hex');
+  const data = Buffer.from(encrypted.data, 'hex');
+  const keyBuf = crypto.createHash('sha256').update(key).digest();
+  const decipher = crypto.createDecipheriv('aes-256-gcm', keyBuf, iv);
+  decipher.setAuthTag(tag);
+  const dec = Buffer.concat([decipher.update(data), decipher.final()]);
+  return dec.toString('utf8');
+}
+
+export function generateKey(length = 32): string {
+  return generateRandomBytes(length).toString('hex');
+}

--- a/tests/auth/crypto-utils.test.ts
+++ b/tests/auth/crypto-utils.test.ts
@@ -1,0 +1,28 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  generateRandomBytes,
+  generateRandomString,
+  encryptAESGCM,
+  decryptAESGCM,
+  hashSHA256
+} from '../../src/auth/utils/crypto-utils.js';
+
+test('generateRandomString creates string of expected length', () => {
+  const str = generateRandomString(16);
+  assert.equal(str.length, 32); // hex length = bytes*2
+});
+
+test('encryptAESGCM and decryptAESGCM roundtrip', () => {
+  const key = 'secret-key';
+  const plaintext = 'hello world';
+  const encrypted = encryptAESGCM(plaintext, key);
+  const decrypted = decryptAESGCM(encrypted, key);
+  assert.equal(decrypted, plaintext);
+});
+
+test('hashSHA256 returns consistent digest', () => {
+  const a = hashSHA256('data');
+  const b = hashSHA256('data');
+  assert.equal(a, b);
+});


### PR DESCRIPTION
## Summary
- add AES-GCM based crypto utility functions
- add tests for crypto utils
- mark crypto utils complete in checklist
- update agent progress note

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852011ba6a4832797c47273825cb04f