### PR TITLE
Implement AuthManager skeleton

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -194,14 +194,14 @@ If you encounter:
 
 ## 🎯 Current Focus
 
-**NEXT IMMEDIATE TASK**: Implement PKCE utilities and base provider ✅
-1. Create `src/auth/utils/pkce-utils.ts`
-2. Create `src/auth/providers/base-provider.ts`
+**NEXT IMMEDIATE TASK**: Implement AuthManager and update checklist ✅
+1. Create `src/auth/managers/auth-manager.ts`
+2. Add basic unit tests
 3. Update `docs/oidc-oauth2-checklist.md` progress
 4. Document any issues encountered
 
 ---
 
-**Last Updated**: 2025年6月18日 (crypto utils implemented, conflicts resolved)
+**Last Updated**: 2025年6月18日 (AuthManager skeleton added)
 **Current Phase**: Phase 1 - Security Foundation
 **Next Milestone**: Configuration Template System

--- a/docs/oidc-oauth2-checklist.md
+++ b/docs/oidc-oauth2-checklist.md
@@ -41,7 +41,7 @@
 - [x] `src/auth/utils/crypto-utils.ts` - 暗号化ユーティリティ
 
 ### 1.4 認証フロー実装
-- [ ] `src/auth/managers/auth-manager.ts` - 認証フローの中央管理
+- [x] `src/auth/managers/auth-manager.ts` - 認証フローの中央管理
 - [ ] `src/routes/auth.ts` - 認証エンドポイント
   - [ ] `GET /auth/login/:provider` - ログイン開始
   - [ ] `GET /auth/callback/:provider` - OAuth2コールバック
@@ -313,4 +313,4 @@
 
 ---
 
-**最終更新**: 2025年6月17日
+**最終更新**: 2025年6月18日

--- a/src/auth/managers/auth-manager.ts
+++ b/src/auth/managers/auth-manager.ts
@@ -1,0 +1,48 @@
+import { BaseProvider } from '../providers/base-provider.js';
+import { PKCECodes, generatePKCECodes } from '../utils/pkce-utils.js';
+import { OIDCTokenResponse, OIDCUserInfo } from '../types/oidc-types.js';
+
+export interface LoginResult {
+  url: string;
+  pkce: PKCECodes;
+}
+
+export class AuthManager {
+  private providers = new Map<string, BaseProvider>();
+
+  registerProvider(provider: BaseProvider): void {
+    this.providers.set(provider.id, provider);
+  }
+
+  getProvider(id: string): BaseProvider {
+    const provider = this.providers.get(id);
+    if (!provider) {
+      throw new Error(`Provider ${id} not registered`);
+    }
+    return provider;
+  }
+
+  beginLogin(providerId: string, state: string): LoginResult {
+    const provider = this.getProvider(providerId);
+    const pkce = generatePKCECodes();
+    const url = provider.getAuthorizationUrl(state, pkce);
+    return { url, pkce };
+  }
+
+  async handleCallback(
+    providerId: string,
+    code: string,
+    pkce: PKCECodes
+  ): Promise<OIDCTokenResponse> {
+    const provider = this.getProvider(providerId);
+    return provider.exchangeCode(code, pkce);
+  }
+
+  async getUserInfo(
+    providerId: string,
+    accessToken: string
+  ): Promise<OIDCUserInfo | undefined> {
+    const provider = this.getProvider(providerId);
+    return provider.getUserInfo(accessToken);
+  }
+}

--- a/src/auth/providers/base-provider.ts
+++ b/src/auth/providers/base-provider.ts
@@ -35,5 +35,16 @@ export abstract class BaseProvider {
     return res.json() as Promise<OIDCTokenResponse>;
   }
 
+  async exchangeCode(code: string, pkce: PKCECodes): Promise<OIDCTokenResponse> {
+    const params = {
+      grant_type: 'authorization_code',
+      code,
+      client_id: this.config.clientId,
+      redirect_uri: this.config.redirectUri,
+      code_verifier: pkce.codeVerifier
+    };
+    return this.requestToken(params);
+  }
+
   abstract getUserInfo(accessToken: string): Promise<OIDCUserInfo | undefined>;
 }

--- a/tests/auth/auth-manager.test.ts
+++ b/tests/auth/auth-manager.test.ts
@@ -1,0 +1,58 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AuthManager } from '../../src/auth/managers/auth-manager.js';
+import { BaseProvider, OAuthProviderConfig } from '../../src/auth/providers/base-provider.js';
+import { PKCECodes } from '../../src/auth/utils/pkce-utils.js';
+
+class DummyProvider extends BaseProvider {
+  lastParams: Record<string, string> | undefined;
+  constructor(id: string, config: OAuthProviderConfig) {
+    super(id, {
+      issuer: 'https://example.com',
+      authorizationEndpoint: 'https://example.com/authorize',
+      tokenEndpoint: 'https://example.com/token',
+      jwksUri: 'https://example.com/jwks'
+    }, config);
+  }
+
+  getAuthorizationUrl(state: string, pkce: PKCECodes): string {
+    const url = new URL(this.metadata.authorizationEndpoint);
+    url.searchParams.set('client_id', this.config.clientId);
+    url.searchParams.set('redirect_uri', this.config.redirectUri);
+    url.searchParams.set('state', state);
+    url.searchParams.set('code_challenge', pkce.codeChallenge);
+    url.searchParams.set('code_challenge_method', pkce.method);
+    return url.toString();
+  }
+
+  async getUserInfo(): Promise<undefined> {
+    return undefined;
+  }
+}
+
+test('AuthManager.beginLogin returns url and pkce', () => {
+  const manager = new AuthManager();
+  const provider = new DummyProvider('dummy', { clientId: 'id', clientSecret: 'secret', redirectUri: 'https://app/cb' });
+  manager.registerProvider(provider);
+
+  const result = manager.beginLogin('dummy', 'state123');
+  assert.ok(result.url.includes('state=state123'));
+  assert.ok(result.pkce.codeVerifier.length > 0);
+});
+
+test('AuthManager.handleCallback exchanges code using provider', async () => {
+  const manager = new AuthManager();
+  const provider = new DummyProvider('dummy', { clientId: 'id', clientSecret: 'secret', redirectUri: 'https://app/cb' });
+  manager.registerProvider(provider);
+
+  const expected = { access_token: 'token', token_type: 'Bearer' };
+  // patch fetch to simulate token response
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify(expected), { status: 200, headers: { 'Content-Type': 'application/json' } });
+
+  const pkce: PKCECodes = { codeVerifier: 'verifier', codeChallenge: 'challenge', method: 'S256' };
+  const res = await manager.handleCallback('dummy', 'code123', pkce);
+  assert.deepEqual(res, expected);
+
+  globalThis.fetch = originalFetch;
+});


### PR DESCRIPTION
## Summary
- add `AuthManager` manager class for login flow
- expose `exchangeCode` method in `BaseProvider`
- test the new manager
- update OIDC/OAuth2 checklist progress
- update AGENT task list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685207ef30c48327afc37606fea88e8d