### PR TITLE
Implement Google OAuth2 provider

### DIFF
--- a/docs/oidc-oauth2-checklist.md
+++ b/docs/oidc-oauth2-checklist.md
@@ -114,10 +114,10 @@
   - [ ] API テスト
 
 ### 2.1 Google OAuth2
-- [ ] `src/auth/providers/google-provider.ts`
-- [ ] Google People API 連携
-- [ ] プロフィール情報取得
-- [ ] テストケース作成
+- [x] `src/auth/providers/google-provider.ts`
+- [x] Google People API 連携
+- [x] プロフィール情報取得
+- [x] テストケース作成
 
 ### 2.2 Microsoft Azure AD
 - [ ] `src/auth/providers/azure-provider.ts`

--- a/src/auth/providers/google-provider.ts
+++ b/src/auth/providers/google-provider.ts
@@ -1,0 +1,52 @@
+import { BaseProvider, OAuthProviderConfig } from './base-provider.js';
+import { PKCECodes } from '../utils/pkce-utils.js';
+import { OIDCProviderMetadata, OIDCUserInfo } from '../types/oidc-types.js';
+
+/**
+ * Google OAuth2 provider implementation.
+ */
+export class GoogleProvider extends BaseProvider {
+  constructor(config: OAuthProviderConfig) {
+    const metadata: OIDCProviderMetadata = {
+      issuer: 'https://accounts.google.com',
+      authorizationEndpoint: 'https://accounts.google.com/o/oauth2/v2/auth',
+      tokenEndpoint: 'https://oauth2.googleapis.com/token',
+      userInfoEndpoint: 'https://openidconnect.googleapis.com/v1/userinfo',
+      jwksUri: 'https://www.googleapis.com/oauth2/v3/certs'
+    };
+    super('google', metadata, config);
+  }
+
+  getAuthorizationUrl(state: string, pkce: PKCECodes): string {
+    const url = new URL(this.metadata.authorizationEndpoint);
+    url.searchParams.set('response_type', 'code');
+    url.searchParams.set('client_id', this.config.clientId);
+    url.searchParams.set('redirect_uri', this.config.redirectUri);
+    url.searchParams.set('scope', this.config.scope || 'openid email profile');
+    url.searchParams.set('state', state);
+    url.searchParams.set('code_challenge', pkce.codeChallenge);
+    url.searchParams.set('code_challenge_method', pkce.method);
+    url.searchParams.set('access_type', 'offline');
+    url.searchParams.set('prompt', 'consent');
+    return url.toString();
+  }
+
+  async getUserInfo(accessToken: string): Promise<OIDCUserInfo | undefined> {
+    if (!this.metadata.userInfoEndpoint) return undefined;
+    const res = await fetch(this.metadata.userInfoEndpoint, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`
+      }
+    });
+    if (!res.ok) {
+      throw new Error(`Failed to fetch user info: ${res.status}`);
+    }
+    const data: any = await res.json();
+    return {
+      sub: data.sub,
+      name: data.name,
+      email: data.email,
+      picture: data.picture
+    };
+  }
+}

--- a/tests/auth/google-provider.test.ts
+++ b/tests/auth/google-provider.test.ts
@@ -1,0 +1,34 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { GoogleProvider } from '../../src/auth/providers/google-provider.js';
+
+const config = {
+  clientId: 'id',
+  clientSecret: 'secret',
+  redirectUri: 'https://app/cb',
+  scope: 'openid email profile'
+};
+
+test('GoogleProvider generates authorization url', () => {
+  const provider = new GoogleProvider(config);
+  const url = provider.getAuthorizationUrl('state1', {
+    codeVerifier: 'verifier',
+    codeChallenge: 'challenge',
+    method: 'S256'
+  });
+  const u = new URL(url);
+  assert.equal(u.hostname, 'accounts.google.com');
+  assert.equal(u.searchParams.get('client_id'), 'id');
+  assert.equal(u.searchParams.get('state'), 'state1');
+  assert.equal(u.searchParams.get('code_challenge'), 'challenge');
+});
+
+test('GoogleProvider.getUserInfo parses response', async () => {
+  const provider = new GoogleProvider(config);
+  const expected = { sub: '1', name: 't', email: 'e', picture: 'p' };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify(expected), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  const result = await provider.getUserInfo('token');
+  assert.deepEqual(result, expected);
+  globalThis.fetch = originalFetch;
+});


### PR DESCRIPTION
## Summary
- add GoogleProvider for OAuth2 support
- test GoogleProvider logic
- mark Google provider tasks complete in checklist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68526ecda36083278c18c16ee2661026