### PR TITLE
Implement GitHub OAuth2 provider

### DIFF
--- a/docs/oidc-oauth2-checklist.md
+++ b/docs/oidc-oauth2-checklist.md
@@ -126,10 +126,10 @@
 - [x] テストケース作成
 
 ### 2.3 GitHub OAuth2
-- [ ] `src/auth/providers/github-provider.ts`
-- [ ] GitHub API 連携
-- [ ] ユーザー情報取得
-- [ ] テストケース作成
+ - [x] `src/auth/providers/github-provider.ts`
+ - [x] GitHub API 連携
+ - [x] ユーザー情報取得
+ - [x] テストケース作成
 
 ### 2.4 汎用OIDC
 - [ ] `src/auth/providers/generic-oidc.ts`

--- a/src/auth/providers/github-provider.ts
+++ b/src/auth/providers/github-provider.ts
@@ -1,0 +1,71 @@
+import { BaseProvider, OAuthProviderConfig } from './base-provider.js';
+import { PKCECodes } from '../utils/pkce-utils.js';
+import { OIDCProviderMetadata, OIDCUserInfo, OIDCTokenResponse } from '../types/oidc-types.js';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * GitHub OAuth2 provider implementation.
+ */
+export class GitHubProvider extends BaseProvider {
+  constructor(config: OAuthProviderConfig) {
+    const metadata: OIDCProviderMetadata = {
+      issuer: 'https://github.com',
+      authorizationEndpoint: 'https://github.com/login/oauth/authorize',
+      tokenEndpoint: 'https://github.com/login/oauth/access_token',
+      userInfoEndpoint: 'https://api.github.com/user',
+      jwksUri: '' // GitHub does not provide JWKS for OAuth apps
+    };
+    super('github', metadata, config);
+  }
+
+  getAuthorizationUrl(state: string, pkce: PKCECodes): string {
+    const url = new URL(this.metadata.authorizationEndpoint);
+    url.searchParams.set('client_id', this.config.clientId);
+    url.searchParams.set('redirect_uri', this.config.redirectUri);
+    if (this.config.scope) url.searchParams.set('scope', this.config.scope);
+    url.searchParams.set('state', state);
+    url.searchParams.set('code_challenge', pkce.codeChallenge);
+    url.searchParams.set('code_challenge_method', pkce.method);
+    return url.toString();
+  }
+
+  protected async requestToken(params: Record<string, string>): Promise<OIDCTokenResponse> {
+    const body = new URLSearchParams(params).toString();
+    const res = await fetch(this.metadata.tokenEndpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json'
+      },
+      body
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      logger.error(`Token request failed: ${res.status} ${text}`);
+      throw new Error(`Token request failed with status ${res.status}`);
+    }
+
+    return res.json() as Promise<OIDCTokenResponse>;
+  }
+
+  async getUserInfo(accessToken: string): Promise<OIDCUserInfo | undefined> {
+    if (!this.metadata.userInfoEndpoint) return undefined;
+    const res = await fetch(this.metadata.userInfoEndpoint, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: 'application/json'
+      }
+    });
+    if (!res.ok) {
+      throw new Error(`Failed to fetch user info: ${res.status}`);
+    }
+    const data: any = await res.json();
+    return {
+      sub: data.id?.toString(),
+      name: data.name || data.login,
+      email: data.email,
+      picture: data.avatar_url
+    };
+  }
+}

--- a/tests/auth/github-provider.test.ts
+++ b/tests/auth/github-provider.test.ts
@@ -1,0 +1,42 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { GitHubProvider } from '../../src/auth/providers/github-provider.js';
+
+const config = {
+  clientId: 'id',
+  clientSecret: 'secret',
+  redirectUri: 'https://app/cb',
+  scope: 'read:user user:email'
+};
+
+test('GitHubProvider generates authorization url', () => {
+  const provider = new GitHubProvider(config);
+  const url = provider.getAuthorizationUrl('state1', {
+    codeVerifier: 'verifier',
+    codeChallenge: 'challenge',
+    method: 'S256'
+  });
+  const u = new URL(url);
+  assert.equal(u.hostname, 'github.com');
+  assert.equal(u.searchParams.get('client_id'), 'id');
+  assert.equal(u.searchParams.get('state'), 'state1');
+  assert.equal(u.searchParams.get('code_challenge'), 'challenge');
+});
+
+test('GitHubProvider.getUserInfo parses response', async () => {
+  const provider = new GitHubProvider(config);
+  const expected = { id: 1, login: 't', email: 'e', avatar_url: 'p' };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify(expected), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' }
+  });
+  const result = await provider.getUserInfo('token');
+  assert.deepEqual(result, {
+    sub: '1',
+    name: 't',
+    email: 'e',
+    picture: 'p'
+  });
+  globalThis.fetch = originalFetch;
+});


### PR DESCRIPTION
## Summary
- add `GitHubProvider` for OAuth2 authentication
- mark GitHub provider tasks complete in checklist
- test GitHub provider implementation

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685284491cbc832780af8e4f0a932cdc