### PR TITLE
Add generic OIDC provider

### DIFF
--- a/docs/oidc-oauth2-checklist.md
+++ b/docs/oidc-oauth2-checklist.md
@@ -132,9 +132,9 @@
  - [x] テストケース作成
 
 ### 2.4 汎用OIDC
-- [ ] `src/auth/providers/generic-oidc.ts`
-- [ ] OpenID Connect Discovery 対応
-- [ ] カスタムプロバイダー対応
+- [x] `src/auth/providers/generic-oidc.ts`
+- [x] OpenID Connect Discovery 対応
+- [x] カスタムプロバイダー対応
 
 ## Phase 3: API保護とRBAC ⏳
 

--- a/src/auth/providers/generic-oidc.ts
+++ b/src/auth/providers/generic-oidc.ts
@@ -1,0 +1,79 @@
+import { BaseProvider, OAuthProviderConfig } from './base-provider.js';
+import { OIDCProviderMetadata, OIDCUserInfo } from '../types/oidc-types.js';
+import { PKCECodes } from '../utils/pkce-utils.js';
+import { logger } from '../../utils/logger.js';
+
+export interface GenericOIDCConfig extends OAuthProviderConfig {
+  issuer: string;
+  discovery?: boolean;
+  metadata?: Partial<OIDCProviderMetadata>;
+}
+
+/**
+ * Generic OIDC provider which uses OpenID Connect Discovery if enabled.
+ */
+export class GenericOIDCProvider extends BaseProvider {
+  private static async fetchMetadata(issuer: string): Promise<OIDCProviderMetadata> {
+    const url = issuer.replace(/\/$/, '') + '/.well-known/openid-configuration';
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`Failed to fetch OIDC metadata: ${res.status}`);
+    }
+    const data = (await res.json()) as any;
+    return {
+      issuer: data.issuer,
+      authorizationEndpoint: data.authorization_endpoint,
+      tokenEndpoint: data.token_endpoint,
+      userInfoEndpoint: data.userinfo_endpoint,
+      jwksUri: data.jwks_uri
+    };
+  }
+
+  constructor(private readonly options: GenericOIDCConfig) {
+    super(
+      'generic-oidc',
+      {
+        issuer: options.issuer,
+        authorizationEndpoint: options.metadata?.authorizationEndpoint || '',
+        tokenEndpoint: options.metadata?.tokenEndpoint || '',
+        userInfoEndpoint: options.metadata?.userInfoEndpoint || '',
+        jwksUri: options.metadata?.jwksUri || ''
+      },
+      options
+    );
+  }
+
+  async init(): Promise<void> {
+    if (this.options.discovery) {
+      logger.info(`Fetching OIDC discovery metadata from ${this.options.issuer}`);
+      const meta = await GenericOIDCProvider.fetchMetadata(this.options.issuer);
+      this.metadata.authorizationEndpoint = meta.authorizationEndpoint;
+      this.metadata.tokenEndpoint = meta.tokenEndpoint;
+      this.metadata.userInfoEndpoint = meta.userInfoEndpoint;
+      this.metadata.jwksUri = meta.jwksUri;
+    }
+  }
+
+  getAuthorizationUrl(state: string, pkce: PKCECodes): string {
+    const url = new URL(this.metadata.authorizationEndpoint);
+    url.searchParams.set('response_type', 'code');
+    url.searchParams.set('client_id', this.options.clientId);
+    url.searchParams.set('redirect_uri', this.options.redirectUri);
+    url.searchParams.set('scope', this.options.scope || 'openid profile email');
+    url.searchParams.set('state', state);
+    url.searchParams.set('code_challenge', pkce.codeChallenge);
+    url.searchParams.set('code_challenge_method', pkce.method);
+    return url.toString();
+  }
+
+  async getUserInfo(accessToken: string): Promise<OIDCUserInfo | undefined> {
+    if (!this.metadata.userInfoEndpoint) return undefined;
+    const res = await fetch(this.metadata.userInfoEndpoint, {
+      headers: { Authorization: `Bearer ${accessToken}` }
+    });
+    if (!res.ok) {
+      throw new Error(`Failed to fetch user info: ${res.status}`);
+    }
+    return res.json() as Promise<OIDCUserInfo>;
+  }
+}

--- a/tests/auth/generic-oidc-provider.test.ts
+++ b/tests/auth/generic-oidc-provider.test.ts
@@ -1,0 +1,55 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { GenericOIDCProvider } from '../../src/auth/providers/generic-oidc.js';
+
+const config = {
+  issuer: 'https://idp.example.com',
+  clientId: 'id',
+  clientSecret: 'secret',
+  redirectUri: 'https://app/cb',
+  discovery: true,
+  scope: 'openid profile'
+};
+
+const discoveryResponse = {
+  issuer: 'https://idp.example.com',
+  authorization_endpoint: 'https://idp.example.com/authorize',
+  token_endpoint: 'https://idp.example.com/token',
+  userinfo_endpoint: 'https://idp.example.com/userinfo',
+  jwks_uri: 'https://idp.example.com/jwks'
+};
+
+test('GenericOIDCProvider discovery fetches metadata', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url: RequestInfo | URL) => {
+    assert.equal(url.toString(), 'https://idp.example.com/.well-known/openid-configuration');
+    return new Response(JSON.stringify(discoveryResponse), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  };
+  const provider = new GenericOIDCProvider(config);
+  await provider.init();
+  const url = provider.getAuthorizationUrl('s1', {
+    codeVerifier: 'v',
+    codeChallenge: 'c',
+    method: 'S256'
+  });
+  const u = new URL(url);
+  assert.equal(u.hostname, 'idp.example.com');
+  assert.equal(u.searchParams.get('client_id'), 'id');
+  assert.equal(u.searchParams.get('state'), 's1');
+  globalThis.fetch = originalFetch;
+});
+
+test('GenericOIDCProvider.getUserInfo parses response', async () => {
+  const provider = new GenericOIDCProvider({ ...config, discovery: false });
+  // manually set metadata endpoints
+  (provider as any).metadata.authorizationEndpoint = 'https://idp.example.com/a';
+  (provider as any).metadata.tokenEndpoint = 'https://idp.example.com/t';
+  (provider as any).metadata.userInfoEndpoint = 'https://idp.example.com/u';
+
+  const expected = { sub: '1', name: 't', email: 'e' };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify(expected), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  const result = await provider.getUserInfo('token');
+  assert.deepEqual(result, expected);
+  globalThis.fetch = originalFetch;
+});


### PR DESCRIPTION
## Summary
- implement GenericOIDCProvider to support arbitrary OIDC providers
- cover generic provider with tests
- mark generic provider tasks as complete in the checklist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685286ee565c83278182050437bfae06