### PR TITLE
Implement user configuration API

### DIFF
--- a/docs/oidc-oauth2-checklist.md
+++ b/docs/oidc-oauth2-checklist.md
@@ -100,20 +100,20 @@ MCP ライフサイクルマネージャーおよびリソース監視機能の�
 ## Phase 2: プロバイダー実装 ⏳
 
 ### 🛠️ ユーザー設定管理システム
-- [ ] **ユーザー設定マネージャー**
-  - [ ] `src/config/user-config-manager.ts` - ユーザー設定管理
-  - [ ] 設定マージ・オーバーライドロジック
+- [x] **ユーザー設定マネージャー**
+  - [x] `src/config/user-config-manager.ts` - ユーザー設定管理
+  - [x] 設定マージ・オーバーライドロジック
   - [ ] インスタンス更新・再起動連携
-  - [ ] 設定バリデーション統合
-- [ ] **永続化システム**
-  - [ ] `src/storage/user-settings-store.ts` - 設定永続化インターフェース
-  - [ ] `FileBasedSettingsStore` 実装
+  - [x] 設定バリデーション統合
+- [x] **永続化システム**
+  - [x] `src/storage/user-settings-store.ts` - 設定永続化インターフェース
+  - [x] `FileBasedSettingsStore` 実装
   - [ ] `DatabaseSettingsStore` 実装（オプション）
-  - [ ] `src/storage/settings-encryption.ts` - 設定暗号化
-- [ ] **ユーザー設定API**
-  - [ ] `src/routes/user-config.ts` - ユーザー設定APIエンドポイント
+  - [x] `src/storage/settings-encryption.ts` - 設定暗号化
+- [x] **ユーザー設定API**
+  - [x] `src/routes/user-config.ts` - ユーザー設定APIエンドポイント
   - [ ] 権限チェック統合
-  - [ ] エラーハンドリング
+  - [x] エラーハンドリング
   - [ ] API テスト
 
 ### 2.1 Google OAuth2

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,9 @@ import { registerConfigRoutes } from './routes/config.js';
 import { registerLogRoutes } from './routes/logs.js';
 import { registerServerManagementRoutes } from './routes/server-management.js';
 import { registerAuthRoutes } from './routes/auth.js';
+import { registerUserConfigRoutes } from './routes/user-config.js';
 import { AuthManager } from './auth/managers/auth-manager.js';
+import { UserConfigManager } from './config/user-config-manager.js';
 import { registerErrorHandler } from './middleware/error-handler.js';
 
 // Server instance reference for restart functionality
@@ -50,6 +52,7 @@ app.use(express.json());
 const mcpManager = new MCPBridgeManager();
 const toolRegistry = new BridgeToolRegistry(mcpManager, mcpConfig, configPath);
 const authManager = new AuthManager();
+const userConfigManager = new UserConfigManager();
 // Set reference to the tool registry
 mcpManager.setToolRegistry(toolRegistry);
 
@@ -131,6 +134,7 @@ registerToolRoutes(app, { mcpManager });
 registerToolAliasRoutes(app, { toolRegistry });
 registerResourceRoutes(app, { mcpManager });
 registerAuthRoutes(app, { authManager });
+registerUserConfigRoutes(app, { userConfigManager });
 registerConfigRoutes(app, { toolRegistry, mcpManager, restartServerOnNewPort });
 registerLogRoutes(app);
 registerServerManagementRoutes(app, { 

--- a/src/routes/user-config.ts
+++ b/src/routes/user-config.ts
@@ -1,0 +1,165 @@
+import express from 'express';
+import { UserConfigManager } from '../config/user-config-manager.js';
+import { ValidationError, SecurityError, AuthContext } from '../config/config-validation.js';
+
+export interface UserConfigRouteContext {
+  userConfigManager: UserConfigManager;
+}
+
+export interface AuthenticatedRequest extends express.Request {
+  user?: { id: string; email?: string };
+  authContext?: AuthContext;
+}
+
+export const getTemplatesHandler = (context: UserConfigRouteContext) =>
+  async (req: AuthenticatedRequest, res: express.Response) => {
+    try {
+      const authCtx = req.authContext || { userId: req.user?.id };
+      const templates = await context.userConfigManager.getAvailableTemplates(authCtx);
+      res.json({ success: true, data: { templates } });
+    } catch (error: any) {
+      res.status(500).json({ success: false, error: error.message });
+    }
+  };
+
+export const getUserSettingsHandler = (context: UserConfigRouteContext) =>
+  async (req: AuthenticatedRequest, res: express.Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ success: false, error: 'Not authenticated' });
+      const settings = await context.userConfigManager.getUserSettings(userId);
+      res.json({ success: true, data: { settings } });
+    } catch (error: any) {
+      res.status(500).json({ success: false, error: error.message });
+    }
+  };
+
+export const updateUserSettingsHandler = (context: UserConfigRouteContext) =>
+  async (req: AuthenticatedRequest, res: express.Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ success: false, error: 'Not authenticated' });
+      const authCtx = req.authContext || { userId };
+      const { settings } = req.body;
+      const updated = await context.userConfigManager.updateUserSettings(userId, settings, authCtx);
+      res.json({ success: true, data: { settings: updated }, message: 'Settings updated successfully' });
+    } catch (error: any) {
+      if (error instanceof ValidationError) {
+        res.status(400).json({ success: false, error: error.message, type: 'validation_error' });
+      } else if (error instanceof SecurityError) {
+        res.status(403).json({ success: false, error: error.message, type: 'security_error' });
+      } else {
+        res.status(500).json({ success: false, error: error.message });
+      }
+    }
+  };
+
+export const updateServerSettingsHandler = (context: UserConfigRouteContext) =>
+  async (req: AuthenticatedRequest, res: express.Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ success: false, error: 'Not authenticated' });
+      const { templateId } = req.params;
+      const { enabled, customization } = req.body;
+      const authCtx = req.authContext || { userId };
+      const current = await context.userConfigManager.getUserSettings(userId);
+      const updated = await context.userConfigManager.updateUserSettings(
+        userId,
+        {
+          serverSettings: {
+            ...current.serverSettings,
+            [templateId]: {
+              templateId,
+              enabled: enabled !== undefined ? enabled : true,
+              customization: customization || {},
+              lastModified: new Date(),
+              version: (current.serverSettings[templateId]?.version || 0) + 1
+            }
+          }
+        },
+        authCtx
+      );
+      res.json({ success: true, data: { settings: updated }, message: `Server ${templateId} settings updated` });
+    } catch (error: any) {
+      res.status(500).json({ success: false, error: error.message });
+    }
+  };
+
+export const toggleServerHandler = (context: UserConfigRouteContext) =>
+  async (req: AuthenticatedRequest, res: express.Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ success: false, error: 'Not authenticated' });
+      const { templateId } = req.params;
+      const { enabled } = req.body;
+      const authCtx = req.authContext || { userId };
+      const current = await context.userConfigManager.getUserSettings(userId);
+      const serverSettings = current.serverSettings[templateId];
+      if (!serverSettings) return res.status(404).json({ success: false, error: 'Server settings not found' });
+      const updated = await context.userConfigManager.updateUserSettings(
+        userId,
+        {
+          serverSettings: {
+            ...current.serverSettings,
+            [templateId]: {
+              ...serverSettings,
+              enabled,
+              lastModified: new Date(),
+              version: serverSettings.version + 1
+            }
+          }
+        },
+        authCtx
+      );
+      res.json({ success: true, data: { enabled }, message: `Server ${templateId} ${enabled ? 'enabled' : 'disabled'}` });
+    } catch (error: any) {
+      res.status(500).json({ success: false, error: error.message });
+    }
+  };
+
+export const previewConfigHandler = (context: UserConfigRouteContext) =>
+  async (req: AuthenticatedRequest, res: express.Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ success: false, error: 'Not authenticated' });
+      const authCtx = req.authContext || { userId };
+      const configs = await context.userConfigManager.generateMCPConfig(userId, authCtx);
+      res.json({ success: true, data: { configs } });
+    } catch (error: any) {
+      res.status(500).json({ success: false, error: error.message });
+    }
+  };
+
+export const resetServerSettingsHandler = (context: UserConfigRouteContext) =>
+  async (req: AuthenticatedRequest, res: express.Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ success: false, error: 'Not authenticated' });
+      const { templateId } = req.params;
+      const authCtx = req.authContext || { userId };
+      const current = await context.userConfigManager.getUserSettings(userId);
+      const { [templateId]: removed, ...remaining } = current.serverSettings;
+      const updated = await context.userConfigManager.updateUserSettings(
+        userId,
+        { serverSettings: remaining },
+        authCtx
+      );
+      res.json({ success: true, data: { settings: updated }, message: `Server ${templateId} settings reset` });
+    } catch (error: any) {
+      res.status(500).json({ success: false, error: error.message });
+    }
+  };
+
+export const registerUserConfigRoutes = (
+  app: express.Application,
+  context: UserConfigRouteContext
+): void => {
+  app.get('/user-config/templates', getTemplatesHandler(context) as express.RequestHandler);
+  app.get('/user-config/settings', getUserSettingsHandler(context) as express.RequestHandler);
+  app.put('/user-config/settings', updateUserSettingsHandler(context) as express.RequestHandler);
+  app.put('/user-config/settings/:templateId', updateServerSettingsHandler(context) as express.RequestHandler);
+  app.patch('/user-config/settings/:templateId/toggle', toggleServerHandler(context) as express.RequestHandler);
+  app.get('/user-config/preview', previewConfigHandler(context) as express.RequestHandler);
+  app.delete('/user-config/settings/:templateId', resetServerSettingsHandler(context) as express.RequestHandler);
+};
+


### PR DESCRIPTION
## Summary
- add user-config routes for managing per-user MCP settings
- integrate userConfigManager into index
- update OIDC/OAuth2 checklist progress

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852adccc2108327962fa0bc09ae90ae