### PR TITLE
Implement OAuth token refresh

### DIFF
--- a/docs/oidc-oauth2-checklist.md
+++ b/docs/oidc-oauth2-checklist.md
@@ -48,7 +48,7 @@
   - [x] `POST /auth/logout` - ログアウト
   - [x] `GET /auth/user` - ユーザー情報取得
   - [x] `GET /auth/status` - 認証ステータス確認
-  - [x] `POST /auth/refresh` - トークンリフレッシュ（TODO実装）
+  - [x] `POST /auth/refresh` - トークンリフレッシュ
 
 ### 1.5 テスト
 - [ ] 認証設定の単体テスト

--- a/src/auth/managers/auth-manager.ts
+++ b/src/auth/managers/auth-manager.ts
@@ -45,4 +45,12 @@ export class AuthManager {
     const provider = this.getProvider(providerId);
     return provider.getUserInfo(accessToken);
   }
+
+  async refreshAccessToken(
+    providerId: string,
+    refreshToken: string
+  ): Promise<OIDCTokenResponse> {
+    const provider = this.getProvider(providerId);
+    return provider.refreshToken(refreshToken);
+  }
 }

--- a/src/auth/providers/base-provider.ts
+++ b/src/auth/providers/base-provider.ts
@@ -46,5 +46,14 @@ export abstract class BaseProvider {
     return this.requestToken(params);
   }
 
+  async refreshToken(refreshToken: string): Promise<OIDCTokenResponse> {
+    const params = {
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+      client_id: this.config.clientId
+    };
+    return this.requestToken(params);
+  }
+
   abstract getUserInfo(accessToken: string): Promise<OIDCUserInfo | undefined>;
 }

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -276,10 +276,14 @@ export const refreshTokenHandler = (context: AuthRouteContext) =>
         return;
       }
 
-      // TODO: Implement token refresh logic with the provider
-      // This would require extending the BaseProvider to support refresh tokens
-      
-      res.status(501).json({ error: 'Token refresh not yet implemented' });
+      const tokens = await context.authManager.refreshAccessToken(
+        sessionData.providerId!,
+        sessionData.tokens.refresh_token
+      );
+      sessionData.tokens = tokens;
+      sessionStore.set(sessionId, sessionData);
+
+      res.json({ tokens });
 
     } catch (error) {
       logger.error('Token refresh failed:', error);

--- a/tests/auth/auth-manager.test.ts
+++ b/tests/auth/auth-manager.test.ts
@@ -56,3 +56,18 @@ test('AuthManager.handleCallback exchanges code using provider', async () => {
 
   globalThis.fetch = originalFetch;
 });
+
+test('AuthManager.refreshAccessToken uses provider', async () => {
+  const manager = new AuthManager();
+  const provider = new DummyProvider('dummy', { clientId: 'id', clientSecret: 'secret', redirectUri: 'https://app/cb' });
+  manager.registerProvider(provider);
+
+  const expected = { access_token: 'newtoken', token_type: 'Bearer' };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify(expected), { status: 200, headers: { 'Content-Type': 'application/json' } });
+
+  const res = await manager.refreshAccessToken('dummy', 'r1');
+  assert.deepEqual(res, expected);
+
+  globalThis.fetch = originalFetch;
+});


### PR DESCRIPTION
## Summary
- support OAuth refresh tokens in `BaseProvider`
- expose `refreshAccessToken` via `AuthManager`
- implement `/auth/refresh` route logic
- update checklist docs
- test refresh token support for providers and manager

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852b558e6b483279f16225d2de36210