### PR TITLE
Implement DatabaseSettingsStore

### DIFF
--- a/docs/oidc-oauth2-checklist.md
+++ b/docs/oidc-oauth2-checklist.md
@@ -108,7 +108,7 @@ MCP ライフサイクルマネージャーおよびリソース監視機能の�
 - [x] **永続化システム**
   - [x] `src/storage/user-settings-store.ts` - 設定永続化インターフェース
   - [x] `FileBasedSettingsStore` 実装
-  - [ ] `DatabaseSettingsStore` 実装（オプション）
+  - [x] `DatabaseSettingsStore` 実装（オプション）
   - [x] `src/storage/settings-encryption.ts` - 設定暗号化
 - [x] **ユーザー設定API**
   - [x] `src/routes/user-config.ts` - ユーザー設定APIエンドポイント

--- a/src/storage/database-settings-store.ts
+++ b/src/storage/database-settings-store.ts
@@ -1,0 +1,47 @@
+export interface QueryResult<T = any> {
+  rows: T[];
+}
+
+export interface Database {
+  query<T = any>(sql: string, params?: any[]): Promise<QueryResult<T>>;
+}
+
+import { UserSettingsStore } from './user-settings-store.js';
+
+/**
+ * Database-backed implementation of UserSettingsStore.
+ */
+export class DatabaseSettingsStore implements UserSettingsStore {
+  constructor(private readonly db: Database) {}
+
+  async getSettings(userId: string): Promise<string | null> {
+    const result = await this.db.query<{ settings_json: string }>(
+      'SELECT settings_json FROM user_settings WHERE user_id = ?',
+      [userId]
+    );
+    return result.rows[0]?.settings_json ?? null;
+  }
+
+  async saveSettings(userId: string, encryptedSettings: string): Promise<void> {
+    await this.db.query(
+      `INSERT INTO user_settings (user_id, settings_json)
+       VALUES (?, ?)
+       ON CONFLICT(user_id) DO UPDATE SET
+         settings_json = excluded.settings_json,
+         updated_at = CURRENT_TIMESTAMP,
+         version = COALESCE(user_settings.version, 0) + 1`,
+      [userId, encryptedSettings]
+    );
+  }
+
+  async deleteSettings(userId: string): Promise<void> {
+    await this.db.query('DELETE FROM user_settings WHERE user_id = ?', [userId]);
+  }
+
+  async listUsers(): Promise<string[]> {
+    const result = await this.db.query<{ user_id: string }>(
+      'SELECT user_id FROM user_settings ORDER BY created_at'
+    );
+    return result.rows.map((r) => r.user_id);
+  }
+}

--- a/src/storage/user-settings-store.ts
+++ b/src/storage/user-settings-store.ts
@@ -62,3 +62,6 @@ export class FileBasedSettingsStore implements UserSettingsStore {
     await fs.mkdir(this.storageDir, { recursive: true }).catch(() => undefined);
   }
 }
+
+export { DatabaseSettingsStore } from './database-settings-store.js';
+export type { Database, QueryResult } from './database-settings-store.js';

--- a/tests/config/database-settings-store.test.ts
+++ b/tests/config/database-settings-store.test.ts
@@ -1,0 +1,49 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { DatabaseSettingsStore, Database, QueryResult } from '../../src/storage/user-settings-store.js';
+
+class MockDatabase implements Database {
+  private data = new Map<string, { settings_json: string; created_at: number; version: number }>();
+
+  async query<T = any>(sql: string, params: any[] = []): Promise<QueryResult<T>> {
+    if (sql.startsWith('SELECT settings_json')) {
+      const userId = params[0];
+      const record = this.data.get(userId);
+      return { rows: record ? [{ settings_json: record.settings_json }] as T[] : [] };
+    }
+    if (sql.startsWith('INSERT INTO user_settings')) {
+      const [userId, json] = params as [string, string];
+      const existing = this.data.get(userId);
+      this.data.set(userId, { settings_json: json, created_at: Date.now(), version: (existing?.version ?? 0) + 1 });
+      return { rows: [] };
+    }
+    if (sql.startsWith('DELETE FROM user_settings')) {
+      const userId = params[0];
+      this.data.delete(userId);
+      return { rows: [] };
+    }
+    if (sql.startsWith('SELECT user_id FROM user_settings')) {
+      const rows = Array.from(this.data.keys()).sort().map(id => ({ user_id: id }));
+      return { rows: rows as T[] };
+    }
+    throw new Error('Unsupported query: ' + sql);
+  }
+}
+
+test('database settings store CRUD', async () => {
+  const db = new MockDatabase();
+  const store = new DatabaseSettingsStore(db);
+  const userId = 'user1';
+
+  const first = await store.getSettings(userId);
+  assert.equal(first, null);
+
+  await store.saveSettings(userId, '{"a":1}');
+  assert.equal(await store.getSettings(userId), '{"a":1}');
+
+  const users = await store.listUsers();
+  assert.deepEqual(users, [userId]);
+
+  await store.deleteSettings(userId);
+  assert.equal(await store.getSettings(userId), null);
+});


### PR DESCRIPTION
## Summary
- add a generic database-backed settings store
- export new store interfaces
- cover database-backed store with tests
- mark checklist item as complete

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6852b83fefa08327a2f0e659647b0fd2