### PR TITLE
Implement auth & RBAC middleware

### DIFF
--- a/docs/oidc-oauth2-checklist.md
+++ b/docs/oidc-oauth2-checklist.md
@@ -142,13 +142,13 @@ MCP ライフサイクルマネージャーおよびリソース監視機能の�
 ## Phase 3: API保護とRBAC ⏳
 
 ### 3.1 認証ミドルウェア
-- [ ] `src/middleware/auth-middleware.ts` - JWT検証ミドルウェア
-  - [ ] Bearer トークン検証
+- [x] `src/middleware/auth-middleware.ts` - JWT検証ミドルウェア
+  - [x] Bearer トークン検証
   - [ ] Cookie セッション検証
-  - [ ] エラーハンドリング
-- [ ] `src/middleware/rbac-middleware.ts` - 権限チェック
-  - [ ] ロールベースアクセス制御
-  - [ ] パーミッション検証
+  - [x] エラーハンドリング
+- [x] `src/middleware/rbac-middleware.ts` - 権限チェック
+  - [x] ロールベースアクセス制御
+  - [x] パーミッション検証
   - [ ] 動的権限チェック
 
 ### 3.2 既存ルートの更新

--- a/src/middleware/auth-middleware.ts
+++ b/src/middleware/auth-middleware.ts
@@ -1,0 +1,42 @@
+import express from 'express';
+import { JWTUtils, TokenPayload } from '../auth/utils/jwt-utils.js';
+
+export interface AuthMiddlewareOptions {
+  jwtUtils: JWTUtils;
+  mode: 'disabled' | 'optional' | 'required';
+}
+
+export interface AuthenticatedRequest extends express.Request {
+  user?: TokenPayload;
+}
+
+export function requireAuth(options: AuthMiddlewareOptions): express.RequestHandler {
+  return (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    if (options.mode === 'disabled') {
+      return next();
+    }
+
+    const authHeader = req.headers.authorization;
+    const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : undefined;
+
+    if (!token) {
+      if (options.mode === 'required') {
+        res.status(401).json({ error: 'Authentication required' });
+        return;
+      }
+      return next();
+    }
+
+    try {
+      const payload = options.jwtUtils.verify(token);
+      (req as AuthenticatedRequest).user = payload;
+      next();
+    } catch (err) {
+      if (options.mode === 'required') {
+        res.status(401).json({ error: 'Invalid token' });
+      } else {
+        next();
+      }
+    }
+  };
+}

--- a/src/middleware/rbac-middleware.ts
+++ b/src/middleware/rbac-middleware.ts
@@ -1,0 +1,27 @@
+import express from 'express';
+import { RBACConfig } from '../auth/types/rbac-types.js';
+import { AuthenticatedRequest } from './auth-middleware.js';
+
+export function createRBACMiddleware(rbac: RBACConfig) {
+  return function requirePermission(permission: string): express.RequestHandler {
+    return (req: express.Request, res: express.Response, next: express.NextFunction) => {
+      const user = (req as AuthenticatedRequest).user;
+      if (!user) {
+        res.status(401).json({ error: 'Authentication required' });
+        return;
+      }
+
+      const roles = user.roles && user.roles.length > 0 ? user.roles : [rbac.defaultRole];
+      for (const roleName of roles) {
+        const role = rbac.roles[roleName];
+        if (!role) continue;
+        if (role.permissions.includes('*') || role.permissions.includes(permission)) {
+          next();
+          return;
+        }
+      }
+
+      res.status(403).json({ error: 'Insufficient permissions' });
+    };
+  };
+}

--- a/tests/middleware/auth-middleware.test.ts
+++ b/tests/middleware/auth-middleware.test.ts
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import http from 'http';
+import { generateKeyPairSync } from 'crypto';
+import { JWTUtils } from '../../src/auth/utils/jwt-utils.js';
+import { requireAuth } from '../../src/middleware/auth-middleware.js';
+
+const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+const jwtUtils = new JWTUtils({ issuer: 'test', audience: 'test', expiresIn: '1h' }, privateKey.export({ type: 'pkcs1', format: 'pem' }).toString(), publicKey.export({ type: 'pkcs1', format: 'pem' }).toString());
+
+function createServer(mode: 'disabled' | 'optional' | 'required') {
+  const app = express();
+  app.get('/protected', requireAuth({ jwtUtils, mode }), (_req, res) => {
+    res.json({ ok: true });
+  });
+  return app.listen(0);
+}
+
+test('requireAuth allows valid token', async () => {
+  const token = jwtUtils.sign({ sub: '1', roles: ['admin'] });
+  const server = createServer('required');
+  await new Promise<void>((r) => server.once('listening', r));
+  const { port } = server.address() as any;
+  const data = await new Promise<http.IncomingMessage>((resolve) => {
+    http.get(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path: '/protected',
+        headers: { Authorization: `Bearer ${token}` }
+      },
+      resolve
+    );
+  });
+  assert.equal(data.statusCode, 200);
+  server.close();
+});
+
+test('requireAuth rejects missing token when required', async () => {
+  const server = createServer('required');
+  await new Promise<void>((r) => server.once('listening', r));
+  const { port } = server.address() as any;
+  const res = await new Promise<http.IncomingMessage>((resolve) => {
+    http.get(`http://127.0.0.1:${port}/protected`, resolve);
+  });
+  assert.equal(res.statusCode, 401);
+  server.close();
+});
+
+test('requireAuth passes through when optional and no token', async () => {
+  const server = createServer('optional');
+  await new Promise<void>((r) => server.once('listening', r));
+  const { port } = server.address() as any;
+  const res = await new Promise<http.IncomingMessage>((resolve) => {
+    http.get(`http://127.0.0.1:${port}/protected`, resolve);
+  });
+  assert.equal(res.statusCode, 200);
+  server.close();
+});

--- a/tests/middleware/rbac-middleware.test.ts
+++ b/tests/middleware/rbac-middleware.test.ts
@@ -1,0 +1,52 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import http from 'http';
+import { generateKeyPairSync } from 'crypto';
+import { JWTUtils } from '../../src/auth/utils/jwt-utils.js';
+import { requireAuth } from '../../src/middleware/auth-middleware.js';
+import { createRBACMiddleware } from '../../src/middleware/rbac-middleware.js';
+import { RBACConfig } from '../../src/auth/types/rbac-types.js';
+
+const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+const jwtUtils = new JWTUtils({ issuer: 'test', audience: 'test', expiresIn: '1h' }, privateKey.export({ type: 'pkcs1', format: 'pem' }).toString(), publicKey.export({ type: 'pkcs1', format: 'pem' }).toString());
+
+const rbac: RBACConfig = {
+  defaultRole: 'viewer',
+  roles: {
+    admin: { id: 'admin', name: 'Admin', permissions: ['*'], isSystemRole: true },
+    viewer: { id: 'viewer', name: 'Viewer', permissions: ['read'], isSystemRole: true }
+  }
+};
+
+function createServer() {
+  const app = express();
+  const requirePermission = createRBACMiddleware(rbac);
+  app.get('/secure', requireAuth({ jwtUtils, mode: 'required' }), requirePermission('read'), (_req, res) => { res.json({ ok: true }); });
+  app.get('/admin', requireAuth({ jwtUtils, mode: 'required' }), requirePermission('write'), (_req, res) => { res.json({ ok: true }); });
+  return app.listen(0);
+}
+
+test('requirePermission allows when role has permission', async () => {
+  const token = jwtUtils.sign({ sub: '1', roles: ['admin'] });
+  const server = createServer();
+  await new Promise<void>((r) => server.once('listening', r));
+  const { port } = server.address() as any;
+  const res = await new Promise<http.IncomingMessage>((resolve) => {
+    http.get({ hostname: '127.0.0.1', port, path: '/secure', headers: { Authorization: `Bearer ${token}` } }, resolve);
+  });
+  assert.equal(res.statusCode, 200);
+  server.close();
+});
+
+test('requirePermission denies when permission missing', async () => {
+  const token = jwtUtils.sign({ sub: '1', roles: ['viewer'] });
+  const server = createServer();
+  await new Promise<void>((r) => server.once('listening', r));
+  const { port } = server.address() as any;
+  const res = await new Promise<http.IncomingMessage>((resolve) => {
+    http.get({ hostname: '127.0.0.1', port, path: '/admin', headers: { Authorization: `Bearer ${token}` } }, resolve);
+  });
+  assert.equal(res.statusCode, 403);
+  server.close();
+});


### PR DESCRIPTION
## Summary
- add JWT-based `requireAuth` middleware
- add RBAC middleware with role/permission checks
- document progress in OAuth2 checklist
- test middleware behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852c9989a388327b3b2825992fbefd2