### PR TITLE
Add CORS middleware

### DIFF
--- a/docs/oidc-oauth2-checklist.md
+++ b/docs/oidc-oauth2-checklist.md
@@ -225,9 +225,9 @@ MCP ライフサイクルマネージャーおよびリソース監視機能の�
 - [ ] X-Frame-Options
 
 ### CORS設定
-- [ ] `src/middleware/cors-middleware.ts`
-- [ ] オリジン制限
-- [ ] 認証情報付きリクエスト対応
+ - [x] `src/middleware/cors-middleware.ts`
+ - [x] オリジン制限
+ - [x] 認証情報付きリクエスト対応
 
 ### 入力検証
 - [ ] Zod スキーマによるリクエスト検証

--- a/src/config/mcp-config.ts
+++ b/src/config/mcp-config.ts
@@ -89,6 +89,12 @@ export const MCPConfigSchema = z.object({
       listenAddress: z.string().default('127.0.0.1'),
       trustedProxies: z.array(z.string()).default([]),
     }).default({ allowExternalAccess: false, listenAddress: '127.0.0.1', trustedProxies: [] }),
+    cors: z
+      .object({
+        allowedOrigins: z.array(z.string()).default(['*']),
+        allowCredentials: z.boolean().default(false),
+      })
+      .default({ allowedOrigins: ['*'], allowCredentials: false }),
   }).optional(),
   auth: AuthConfigSchema.optional(),
 });
@@ -191,6 +197,10 @@ export function getDefaultConfig(): MCPConfig {
         allowExternalAccess: false,
         listenAddress: '127.0.0.1',
         trustedProxies: [],
+      },
+      cors: {
+        allowedOrigins: ['*'],
+        allowCredentials: false,
       },
     },
     auth: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import express from 'express';
-import cors from 'cors';
+import { createCorsMiddleware } from './middleware/cors-middleware.js';
 import { loadMCPConfig } from './config/mcp-config.js';
 import { listenAddressSecurityManager } from './config/listen-address-security.js';
 import { MCPBridgeManager } from './mcp-bridge-manager.js';
@@ -54,7 +54,8 @@ const port = Number(process.env.PORT || mcpConfig.global?.httpPort || 3000);
 currentPort = port;
 
 // Middleware
-app.use(cors());
+const corsConf = mcpConfig.security?.cors || { allowedOrigins: ['*'], allowCredentials: false };
+app.use(createCorsMiddleware(corsConf));
 app.use(express.json());
 
 // Initialize MCP Bridge Manager and Tool Registry

--- a/src/middleware/cors-middleware.ts
+++ b/src/middleware/cors-middleware.ts
@@ -1,0 +1,40 @@
+import { RequestHandler } from 'express';
+import cors, { CorsOptions } from 'cors';
+
+export interface CorsConfig {
+  allowedOrigins?: string[];
+  allowCredentials?: boolean;
+}
+
+/**
+ * Create a CORS middleware based on the given configuration.
+ * If an origin is not allowed, a 403 response is returned.
+ */
+export function createCorsMiddleware(config: CorsConfig = {}): RequestHandler {
+  const allowed = config.allowedOrigins ?? ['*'];
+  const allowCreds = config.allowCredentials ?? false;
+
+  const options: CorsOptions = {
+    origin: (origin, callback) => {
+      if (!origin) return callback(null, true);
+      if (allowed.includes('*') || allowed.includes(origin)) {
+        callback(null, true);
+      } else {
+        callback(new Error('Not allowed by CORS'));
+      }
+    },
+    credentials: allowCreds
+  };
+
+  const corsMiddleware = cors(options);
+  return (req, res, next) => {
+    corsMiddleware(req, res, (err) => {
+      if (err) {
+        res.status(403).json({ error: 'CORS origin not allowed' });
+      } else {
+        next();
+      }
+    });
+  };
+}
+

--- a/tests/middleware/cors-middleware.test.ts
+++ b/tests/middleware/cors-middleware.test.ts
@@ -1,0 +1,53 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import http from 'http';
+import { createCorsMiddleware } from '../../src/middleware/cors-middleware.js';
+
+function createServer() {
+  const app = express();
+  app.use(createCorsMiddleware({ allowedOrigins: ['http://example.com'], allowCredentials: true }));
+  app.get('/data', (_req, res) => { res.json({ ok: true }); });
+  return app.listen(0);
+}
+
+test('allows configured origin with credentials', async () => {
+  const server = createServer();
+  await new Promise<void>((r) => server.once('listening', r));
+  const { port } = server.address() as any;
+  const res = await new Promise<http.IncomingMessage>((resolve) => {
+    http.get(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path: '/data',
+        headers: { Origin: 'http://example.com' }
+      },
+      resolve
+    );
+  });
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.headers['access-control-allow-origin'], 'http://example.com');
+  assert.equal(res.headers['access-control-allow-credentials'], 'true');
+  server.close();
+});
+
+test('rejects unknown origin', async () => {
+  const server = createServer();
+  await new Promise<void>((r) => server.once('listening', r));
+  const { port } = server.address() as any;
+  const res = await new Promise<http.IncomingMessage>((resolve) => {
+    http.get(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path: '/data',
+        headers: { Origin: 'http://evil.com' }
+      },
+      resolve
+    );
+  });
+  assert.equal(res.statusCode, 403);
+  server.close();
+});
+


### PR DESCRIPTION
## Summary
- implement configurable CORS middleware
- wire middleware in index.ts using security.cors config
- document CORS completion in checklist
- update configuration schema and defaults
- add tests for CORS middleware

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852df2d13608327a54fb57da047e300