### PR TITLE
Implement dynamic authentication reload

### DIFF
--- a/src/auth/managers/auth-manager.ts
+++ b/src/auth/managers/auth-manager.ts
@@ -14,6 +14,10 @@ export class AuthManager {
     this.providers.set(provider.id, provider);
   }
 
+  unregisterAllProviders(): void {
+    this.providers.clear();
+  }
+
   getProvider(id: string): BaseProvider {
     const provider = this.providers.get(id);
     if (!provider) {

--- a/src/auth/utils/jwt-utils.ts
+++ b/src/auth/utils/jwt-utils.ts
@@ -17,6 +17,16 @@ export interface TokenPayload extends JwtPayload {
 export class JWTUtils {
   constructor(private config: JWTConfig, private privateKey: string, private publicKey: string) {}
 
+  updateConfig(config: JWTConfig, privateKey?: string, publicKey?: string): void {
+    this.config = config;
+    if (privateKey) {
+      this.privateKey = privateKey;
+    }
+    if (publicKey) {
+      this.publicKey = publicKey;
+    }
+  }
+
   sign(payload: TokenPayload, options: SignOptions = {}): string {
     try {
       const signOptions: SignOptions = {

--- a/src/middleware/auth-middleware.ts
+++ b/src/middleware/auth-middleware.ts
@@ -20,8 +20,13 @@ export interface AuthenticatedRequest extends express.Request {
   user?: TokenPayload;
 }
 
-export function requireAuth(options: AuthMiddlewareOptions): express.RequestHandler {
-  return (req: express.Request, res: express.Response, next: express.NextFunction) => {
+export interface UpdatableAuthMiddleware extends express.RequestHandler {
+  update(options: AuthMiddlewareOptions): void;
+}
+
+export function requireAuth(initialOptions: AuthMiddlewareOptions): UpdatableAuthMiddleware {
+  let options = { ...initialOptions };
+  const handler = ((req: express.Request, res: express.Response, next: express.NextFunction) => {
     if (options.mode === 'disabled') {
       return next();
     }
@@ -64,5 +69,11 @@ export function requireAuth(options: AuthMiddlewareOptions): express.RequestHand
         next();
       }
     }
+  }) as UpdatableAuthMiddleware;
+
+  handler.update = (newOptions: AuthMiddlewareOptions) => {
+    options = { ...newOptions };
   };
+
+  return handler;
 }


### PR DESCRIPTION
## Summary
- add `updateConfig` method in JWT utilities
- implement updatable authentication and RBAC middleware
- support auth config reload in server index
- expose provider manager cleanup method
- test dynamic middleware update functionality

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685345994b90832784e2c1aa9131a312