### PR TITLE
Implement RBAC role mapping on login

### DIFF
--- a/src/auth/types/oidc-types.ts
+++ b/src/auth/types/oidc-types.ts
@@ -25,4 +25,5 @@ export interface OIDCUserInfo {
   name?: string;
   email?: string;
   picture?: string;
+  roles?: string[];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -253,7 +253,7 @@ registerMCPServerRoutes(app, { mcpManager }, authHandlers);
 registerToolRoutes(app, { mcpManager }, authHandlers);
 registerToolAliasRoutes(app, { toolRegistry }, authHandlers);
 registerResourceRoutes(app, { mcpManager }, authHandlers);
-registerAuthRoutes(app, { authManager });
+registerAuthRoutes(app, { authManager, getRBACConfig: () => authConfig.rbac as any });
 registerUserConfigRoutes(app, { userConfigManager }, authHandlers);
 registerConfigRoutes(app, { toolRegistry, mcpManager, restartServerOnNewPort }, authHandlers);
 registerLogRoutes(app, authHandlers);

--- a/src/middleware/auth-middleware.ts
+++ b/src/middleware/auth-middleware.ts
@@ -43,7 +43,7 @@ export function requireAuth(initialOptions: AuthMiddlewareOptions): UpdatableAut
           (req as AuthenticatedRequest).user = {
             sub: session.user.sub,
             email: session.user.email,
-            roles: []
+            roles: session.user.roles || []
           };
           return next();
         }
@@ -60,7 +60,10 @@ export function requireAuth(initialOptions: AuthMiddlewareOptions): UpdatableAut
 
     try {
       const payload = options.jwtUtils.verify(token);
-      (req as AuthenticatedRequest).user = payload;
+      (req as AuthenticatedRequest).user = {
+        ...payload,
+        roles: payload.roles || []
+      };
       next();
     } catch (err) {
       if (options.mode === 'required') {

--- a/tests/auth/auth-routes.test.ts
+++ b/tests/auth/auth-routes.test.ts
@@ -7,6 +7,7 @@ import { AuthManager } from '../../src/auth/managers/auth-manager.js';
 import { BaseProvider, OAuthProviderConfig } from '../../src/auth/providers/base-provider.js';
 import { registerAuthRoutes } from '../../src/routes/auth.js';
 import { PKCECodes } from '../../src/auth/utils/pkce-utils.js';
+import { sessionStore } from '../../src/auth/session-store.js';
 
 class DummyProvider extends BaseProvider {
   constructor(id: string, config: OAuthProviderConfig) {
@@ -24,7 +25,10 @@ class DummyProvider extends BaseProvider {
     url.searchParams.set('code_challenge_method', pkce.method);
     return url.toString();
   }
-  async getUserInfo(): Promise<{ sub: string }> { return { sub: 'user1' }; }
+  async getUserInfo(accessToken: string): Promise<any> {
+    const res = await fetch('https://example.com/userinfo', { headers: { Authorization: `Bearer ${accessToken}` } });
+    return res.json();
+  }
 }
 
 test('auth routes login and callback flow', async () => {
@@ -43,7 +47,12 @@ test('auth routes login and callback flow', async () => {
   // patch fetch for token request
   const expected = { access_token: 'token', token_type: 'Bearer' };
   const originalFetch = globalThis.fetch;
-  globalThis.fetch = async () => new Response(JSON.stringify(expected), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  globalThis.fetch = async (url: any) => {
+    if (typeof url === 'string' && url.includes('token')) {
+      return new Response(JSON.stringify(expected), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+    return new Response(JSON.stringify({ sub: 'user1', email: 'user@example.com' }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  };
 
   const loginData = await new Promise<any>((resolve, reject) => {
     http.get(`${base}/auth/login/dummy`, (res) => {
@@ -60,6 +69,56 @@ test('auth routes login and callback flow', async () => {
   });
   assert.equal(cbRes.statusCode, 302);
   assert.ok(cbRes.headers.location?.includes('/admin?auth=success'));
+
+  globalThis.fetch = originalFetch;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+test('callback assigns roles from user mappings', async () => {
+  const manager = new AuthManager();
+  const provider = new DummyProvider('dummy', { clientId: 'id', clientSecret: 'sec', redirectUri: 'https://app/cb' });
+  manager.registerProvider(provider);
+
+  const rbac = {
+    defaultRole: 'viewer',
+    roles: {
+      admin: { id: 'admin', name: 'Admin', permissions: ['*'], isSystemRole: true },
+      viewer: { id: 'viewer', name: 'Viewer', permissions: ['read'], isSystemRole: true }
+    },
+    userMappings: [{ email: 'test@example.com', role: 'admin' }]
+  };
+
+  const app = express();
+  app.use(express.json());
+  registerAuthRoutes(app, { authManager: manager, getRBACConfig: () => rbac });
+  const server = app.listen(0);
+  await new Promise<void>((resolve) => server.once('listening', resolve));
+  const address = server.address() as AddressInfo;
+  const base = `http://127.0.0.1:${address.port}`;
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_url: any) => {
+    if (typeof _url === 'string' && _url.includes('token')) {
+      return new Response(JSON.stringify({ access_token: 't', token_type: 'Bearer' }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+    return new Response(JSON.stringify({ sub: '1', email: 'test@example.com' }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  };
+
+  const loginData = await new Promise<any>((resolve, reject) => {
+    http.get(`${base}/auth/login/dummy`, (res) => {
+      let data = '';
+      res.on('data', chunk => { data += chunk; });
+      res.on('end', () => resolve(JSON.parse(data)));
+    }).on('error', reject);
+  });
+  const state = new URL(loginData.authUrl).searchParams.get('state');
+
+  await new Promise<http.IncomingMessage>((resolve, reject) => {
+    http.get(`${base}/auth/callback/dummy?code=abc&state=${state}`,(res) => { res.resume(); resolve(res); }).on('error', reject);
+  });
+
+  const session = sessionStore.get(loginData.sessionId);
+  assert.deepEqual(session?.user?.roles, ['admin']);
 
   globalThis.fetch = originalFetch;
   await new Promise<void>((resolve) => server.close(() => resolve()));


### PR DESCRIPTION
## Summary
- map user roles from RBAC config during OAuth callback
- persist roles in session and propagate through auth middleware
- expose RBAC config to auth routes
- extend OIDC user info type with optional roles
- test role mapping in auth routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68535a80035c8327bfacf80489519bce