### PR TITLE
Implement Zod request validation

### DIFF
--- a/src/middleware/validation.ts
+++ b/src/middleware/validation.ts
@@ -1,0 +1,21 @@
+import express from 'express';
+import { AnyZodObject, ZodError } from 'zod';
+
+/**
+ * Create middleware that validates and sanitizes request bodies using a Zod schema.
+ * The parsed result replaces `req.body` if validation succeeds.
+ *
+ * @param schema - Zod schema to apply to the request body
+ * @returns Express middleware that validates the body
+ */
+export function validateBody(schema: AnyZodObject): express.RequestHandler {
+  return (req, res, next) => {
+    try {
+      req.body = schema.parse(req.body);
+      next();
+    } catch (err) {
+      const zErr = err as ZodError;
+      res.status(400).json({ error: 'Invalid request body', details: zErr.errors });
+    }
+  };
+}

--- a/tests/routes/tool-aliases-validation.test.ts
+++ b/tests/routes/tool-aliases-validation.test.ts
@@ -1,0 +1,59 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import http from 'http';
+import { registerToolAliasRoutes } from '../../src/routes/tool-aliases.js';
+
+function createServer() {
+  const app = express();
+  app.use(express.json());
+  const toolRegistry = {
+    last: null,
+    async handleCreateToolAlias(args: any) {
+      this.last = args;
+      return { success: true, data: args };
+    },
+    async handleUpdateToolAlias() { return { success: true }; },
+    async handleListAliasedTools() { return { tools: [] }; },
+    async handleRemoveToolAlias() { return { success: true }; }
+  } as any;
+  registerToolAliasRoutes(app, { toolRegistry });
+  return { server: app.listen(0), registry: toolRegistry };
+}
+
+test('rejects invalid create alias body', async () => {
+  const { server } = createServer();
+  await new Promise<void>((r) => server.once('listening', r));
+  const { port } = server.address() as any;
+  const res = await new Promise<http.IncomingMessage>((resolve) => {
+    const req = http.request({
+      hostname: '127.0.0.1',
+      port,
+      path: '/mcp/tool-aliases',
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' }
+    }, resolve);
+    req.end(JSON.stringify({ toolName: 't1' }));
+  });
+  assert.equal(res.statusCode, 400);
+  server.close();
+});
+
+test('trims newName in create alias body', async () => {
+  const { server, registry } = createServer();
+  await new Promise<void>((r) => server.once('listening', r));
+  const { port } = server.address() as any;
+  await new Promise<http.IncomingMessage>((resolve) => {
+    const req = http.request({
+      hostname: '127.0.0.1',
+      port,
+      path: '/mcp/tool-aliases',
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' }
+    }, resolve);
+    req.end(JSON.stringify({ serverId: 's1', toolName: 't1', newName: ' alias ' }));
+  });
+  assert.equal(registry.last.newName, 'alias');
+  server.close();
+});
+


### PR DESCRIPTION
## Summary
- add `validateBody` middleware for Zod-based request validation
- validate tool-alias API endpoints with Zod schemas
- add unit tests for alias route validation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68539b24b9608327951490ebf589273a