### PR TITLE
Add admin UI auth context and login page

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -7,6 +7,9 @@ import ToolManagement from './pages/ToolManagement';
 import GlobalSettings from './pages/GlobalSettings';
 import ToolDiscoverySettings from './pages/ToolDiscoverySettings';
 import LogViewer from './pages/LogViewer';
+import LoginPage from './components/LoginPage';
+import RequireAuth from './components/RequireAuth';
+import { AuthProvider } from './contexts/AuthContext';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -20,19 +23,71 @@ const queryClient = new QueryClient({
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <Router>
-        <Layout>
+      <AuthProvider>
+        <Router>
           <Routes>
-            <Route path="/" element={<Navigate to="/dashboard" replace />} />
-            <Route path="/dashboard" element={<Dashboard />} />
-            <Route path="/servers" element={<ServerManagement />} />
-            <Route path="/tools" element={<ToolManagement />} />
-            <Route path="/settings" element={<GlobalSettings />} />
-            <Route path="/discovery" element={<ToolDiscoverySettings />} />
-            <Route path="/logs" element={<LogViewer />} />
+            <Route path="/login" element={<LoginPage />} />
+            <Route
+              path="/*"
+              element={
+                <Layout>
+                  <Routes>
+                    <Route path="/" element={<Navigate to="/dashboard" replace />} />
+                    <Route
+                      path="/dashboard"
+                      element={
+                        <RequireAuth>
+                          <Dashboard />
+                        </RequireAuth>
+                      }
+                    />
+                    <Route
+                      path="/servers"
+                      element={
+                        <RequireAuth>
+                          <ServerManagement />
+                        </RequireAuth>
+                      }
+                    />
+                    <Route
+                      path="/tools"
+                      element={
+                        <RequireAuth>
+                          <ToolManagement />
+                        </RequireAuth>
+                      }
+                    />
+                    <Route
+                      path="/settings"
+                      element={
+                        <RequireAuth>
+                          <GlobalSettings />
+                        </RequireAuth>
+                      }
+                    />
+                    <Route
+                      path="/discovery"
+                      element={
+                        <RequireAuth>
+                          <ToolDiscoverySettings />
+                        </RequireAuth>
+                      }
+                    />
+                    <Route
+                      path="/logs"
+                      element={
+                        <RequireAuth>
+                          <LogViewer />
+                        </RequireAuth>
+                      }
+                    />
+                  </Routes>
+                </Layout>
+              }
+            />
           </Routes>
-        </Layout>
-      </Router>
+        </Router>
+      </AuthProvider>
     </QueryClientProvider>
   );
 }

--- a/admin-ui/src/components/Layout.tsx
+++ b/admin-ui/src/components/Layout.tsx
@@ -1,16 +1,17 @@
 import type { ReactNode } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { 
-  Home, 
-  Server, 
-  Wrench, 
-  Settings, 
+import {
+  Home,
+  Server,
+  Wrench,
+  Settings,
   FileText,
   Menu,
   X,
-  Search 
+  Search
 } from 'lucide-react';
 import { useState } from 'react';
+import UserProfile from './UserProfile';
 
 interface LayoutProps {
   children: ReactNode;
@@ -37,6 +38,7 @@ export default function Layout({ children }: LayoutProps) {
         <div className="fixed inset-y-0 left-0 flex w-64 flex-col bg-white">
           <div className="flex h-16 items-center justify-between px-4 border-b border-gray-200">
             <h1 className="text-xl font-semibold text-gray-900">MCP Bridge</h1>
+            <UserProfile />
             <button
               type="button"
               className="text-gray-400 hover:text-gray-600"
@@ -71,8 +73,9 @@ export default function Layout({ children }: LayoutProps) {
       {/* Desktop sidebar */}
       <div className="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-64 lg:flex-col">
         <div className="flex grow flex-col gap-y-5 overflow-y-auto border-r border-gray-200 bg-white px-6">
-          <div className="flex h-16 shrink-0 items-center">
+          <div className="flex h-16 shrink-0 items-center justify-between">
             <h1 className="text-xl font-semibold text-gray-900">MCP Bridge</h1>
+            <UserProfile />
           </div>
           <nav className="flex flex-1 flex-col">
             <ul role="list" className="flex flex-1 flex-col gap-y-7">

--- a/admin-ui/src/components/LoginPage.tsx
+++ b/admin-ui/src/components/LoginPage.tsx
@@ -1,0 +1,22 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+
+export default function LoginPage() {
+  const { user, login, loading } = useAuth();
+
+  if (!loading && user) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  return (
+    <div className="flex h-screen flex-col items-center justify-center bg-gray-50">
+      <h1 className="mb-4 text-2xl font-semibold">MCP Bridge Admin Login</h1>
+      <button
+        className="rounded bg-primary-600 px-4 py-2 font-medium text-white"
+        onClick={() => login()}
+      >
+        Login with OAuth2
+      </button>
+    </div>
+  );
+}

--- a/admin-ui/src/components/RequireAuth.tsx
+++ b/admin-ui/src/components/RequireAuth.tsx
@@ -1,0 +1,10 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+import { ReactNode } from 'react';
+
+export default function RequireAuth({ children }: { children: ReactNode }) {
+  const { user, loading } = useAuth();
+  if (loading) return null;
+  if (!user) return <Navigate to="/login" replace />;
+  return <>{children}</>;
+}

--- a/admin-ui/src/components/UserProfile.tsx
+++ b/admin-ui/src/components/UserProfile.tsx
@@ -1,0 +1,14 @@
+import { useAuth } from '../hooks/useAuth';
+
+export default function UserProfile() {
+  const { user, logout } = useAuth();
+  if (!user) return null;
+  return (
+    <div className="flex items-center gap-2 text-sm">
+      <span className="font-medium text-gray-700">{user.name || user.email}</span>
+      <button className="text-primary-600" onClick={logout}>
+        Logout
+      </button>
+    </div>
+  );
+}

--- a/admin-ui/src/contexts/AuthContext.tsx
+++ b/admin-ui/src/contexts/AuthContext.tsx
@@ -1,0 +1,59 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import api from '../services/api';
+import type { AuthUser } from '../types/auth';
+
+interface AuthContextValue {
+  user: AuthUser | null;
+  loading: boolean;
+  login(provider?: string): void;
+  logout(): Promise<void>;
+  refresh(): Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchUser = async () => {
+    try {
+      const res = await api.get('/auth/user');
+      setUser(res.data.user);
+    } catch {
+      setUser(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchUser();
+  }, []);
+
+  const login = (provider = 'google') => {
+    window.location.href = `/auth/login/${provider}`;
+  };
+
+  const logout = async () => {
+    await api.post('/auth/logout');
+    setUser(null);
+  };
+
+  const refresh = async () => {
+    setLoading(true);
+    await fetchUser();
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, loading, login, logout, refresh }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuthContext() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuthContext must be used within AuthProvider');
+  return ctx;
+}

--- a/admin-ui/src/hooks/useAuth.ts
+++ b/admin-ui/src/hooks/useAuth.ts
@@ -1,0 +1,5 @@
+import { useAuthContext } from '../contexts/AuthContext';
+
+export function useAuth() {
+  return useAuthContext();
+}

--- a/admin-ui/src/services/mcpBridge.ts
+++ b/admin-ui/src/services/mcpBridge.ts
@@ -1,16 +1,35 @@
 import api from './api';
-import type { 
-  MCPServer, 
-  MCPServerConfig, 
-  Tool, 
-  ToolAlias, 
-  GlobalConfig, 
+import type {
+  MCPServer,
+  MCPServerConfig,
+  Tool,
+  ToolAlias,
+  GlobalConfig,
   ServerStats,
   LogEntry,
   ToolDiscoveryRule
 } from '../types';
+import type { AuthUser } from '../types';
 
 export class MCPBridgeService {
+  // Authentication
+  async getCurrentUser(): Promise<AuthUser | null> {
+    try {
+      const res = await api.get('/auth/user');
+      return res.data.user || null;
+    } catch {
+      return null;
+    }
+  }
+
+  login(provider = 'google'): void {
+    window.location.href = `/auth/login/${provider}`;
+  }
+
+  async logout(): Promise<void> {
+    await api.post('/auth/logout');
+  }
+
   // Server Management
   async getServers(): Promise<MCPServer[]> {
     const response = await api.get('/mcp/servers');

--- a/admin-ui/src/types/auth.ts
+++ b/admin-ui/src/types/auth.ts
@@ -1,0 +1,6 @@
+export interface AuthUser {
+  id: string;
+  email?: string;
+  roles: string[];
+  name?: string;
+}

--- a/admin-ui/src/types/index.ts
+++ b/admin-ui/src/types/index.ts
@@ -92,3 +92,4 @@ export interface LogEntry {
   serverId?: string;
   error?: string;
 }
+export type { AuthUser } from './auth';


### PR DESCRIPTION
## Summary
- add authentication context and hook
- add login page, user profile, and auth guards
- integrate auth into app layout and router
- expose auth-related API methods

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68539efa62248327b5f43fc562522bd1